### PR TITLE
feat: display Google profile photo in header

### DIFF
--- a/docs/superpowers/plans/2026-06-06-google-profile-photo.md
+++ b/docs/superpowers/plans/2026-06-06-google-profile-photo.md
@@ -1,0 +1,201 @@
+# Google Profile Photo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Exibir a foto de perfil do Google no avatar do header, com fallback de iniciais para usuários sem foto.
+
+**Architecture:** Criar o componente `UserAvatar` que encapsula `Avatar / AvatarImage / AvatarFallback` do Radix UI com lógica de iniciais. O `Header` substitui o `div` placeholder atual pelo novo componente, recebendo os dados diretamente da sessão NextAuth via `useSession()`.
+
+**Tech Stack:** Next.js 14 App Router, NextAuth v4, `@radix-ui/react-avatar` (já instalado), TypeScript
+
+---
+
+## File Map
+
+| Ação | Arquivo | Responsabilidade |
+|------|---------|-----------------|
+| Criar | `src/components/user-avatar.tsx` | Renderizar avatar com imagem ou iniciais |
+| Modificar | `src/components/header.tsx` | Substituir `div` placeholder por `<UserAvatar />` |
+
+---
+
+### Task 1: Criar o componente `UserAvatar`
+
+**Files:**
+- Create: `src/components/user-avatar.tsx`
+
+- [ ] **Step 1: Criar o arquivo do componente**
+
+Crie `src/components/user-avatar.tsx` com o seguinte conteúdo:
+
+```tsx
+'use client';
+
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { getBiggestUsernamePart } from '@/utils';
+
+interface UserAvatarProps {
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+}
+
+function getInitials(name?: string | null, email?: string | null): string {
+  if (name) {
+    const parts = name.trim().split(/\s+/);
+    if (parts.length === 1) return parts[0][0].toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+  if (email) {
+    const part = getBiggestUsernamePart(email);
+    return part ? part[0].toUpperCase() : '';
+  }
+  return '';
+}
+
+export function UserAvatar({ name, email, image }: UserAvatarProps) {
+  const initials = getInitials(name, email);
+
+  return (
+    <Avatar className="w-9 h-9 border border-[var(--color-hairline)]">
+      <AvatarImage src={image ?? undefined} alt={name ?? email ?? 'Avatar'} />
+      <AvatarFallback className="bg-[var(--color-surface-card)] text-xs font-semibold text-[var(--color-muted)]">
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/user-avatar.tsx
+git commit -m "feat: add UserAvatar component with Google photo and initials fallback"
+```
+
+---
+
+### Task 2: Integrar `UserAvatar` no `Header`
+
+**Files:**
+- Modify: `src/components/header.tsx:1-7` (imports) e `src/components/header.tsx:31` (placeholder)
+
+- [ ] **Step 1: Adicionar o import**
+
+No topo de `src/components/header.tsx`, adicione o import do `UserAvatar` junto aos demais imports locais:
+
+```tsx
+import { UserAvatar } from '@/components/user-avatar';
+```
+
+O bloco de imports ficará assim:
+
+```tsx
+'use client';
+
+import Link from 'next/link';
+import { useTheme } from 'next-themes';
+import { useState, useEffect } from 'react';
+import { signOut, useSession } from 'next-auth/react';
+import { Sun, Moon, LogIn, LogOut, ShoppingBasket } from 'lucide-react';
+
+import { PagesEnum } from '@/types/enums';
+import { UserAvatar } from '@/components/user-avatar';
+```
+
+- [ ] **Step 2: Substituir o `div` placeholder**
+
+Localize o `div` placeholder atual (dentro do bloco `isLoggedIn`) em `src/components/header.tsx`:
+
+```tsx
+<div className="w-9 h-9 rounded-full bg-[var(--color-surface-card)] border border-[var(--color-hairline)] flex-shrink-0" />
+```
+
+Substitua por:
+
+```tsx
+<UserAvatar
+  name={session?.user?.name}
+  email={session?.user?.email}
+  image={session?.user?.image}
+/>
+```
+
+O bloco `isLoggedIn` completo ficará assim:
+
+```tsx
+{isLoggedIn ? (
+  <div className="flex items-center gap-2">
+    <UserAvatar
+      name={session?.user?.name}
+      email={session?.user?.email}
+      image={session?.user?.image}
+    />
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[13px] font-semibold leading-none text-[var(--color-ink)]">
+        Olá, {firstName}
+      </span>
+      <span className="text-[11px] leading-none text-[var(--color-muted)]">
+        {email}
+      </span>
+    </div>
+  </div>
+) : (
+```
+
+- [ ] **Step 3: Verificar lint e tipos**
+
+```bash
+npm run lint
+npx tsc --noEmit
+```
+
+Esperado: sem erros ou warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/header.tsx
+git commit -m "feat: display Google profile photo in header avatar"
+```
+
+---
+
+### Task 3: Verificação Manual
+
+- [ ] **Step 1: Subir o servidor de desenvolvimento**
+
+```bash
+npm run dev
+```
+
+Acesse `http://localhost:3000`.
+
+- [ ] **Step 2: Verificar usuário Google**
+
+Entre com uma conta Google. Confirme que a foto de perfil aparece no avatar do header (canto superior esquerdo, ao lado de "Olá, [nome]").
+
+- [ ] **Step 3: Verificar usuário email/código**
+
+Entre com email + código OTP. Confirme que as iniciais aparecem no avatar (ex: `FM` para "Fernando Meira", `F` para "Fernando").
+
+- [ ] **Step 4: Verificar fallback de imagem inválida**
+
+No componente `UserAvatar`, temporariamente troque `image` por uma URL inválida (ex: `"https://invalid.url/img.jpg"`) para confirmar que o Radix exibe o `AvatarFallback` com as iniciais. Reverta após o teste.
+
+- [ ] **Step 5: Build final**
+
+```bash
+npm run build
+```
+
+Esperado: build sem erros.

--- a/docs/superpowers/specs/2026-06-06-google-profile-photo-design.md
+++ b/docs/superpowers/specs/2026-06-06-google-profile-photo-design.md
@@ -1,0 +1,75 @@
+# Google Profile Photo — Design Spec
+
+**Data:** 2026-06-06  
+**Escopo:** Exibir a foto de perfil do Google no avatar do header, com fallback de iniciais para usuários sem foto  
+**Abordagem aprovada:** Componente `UserAvatar` dedicado, consumido pelo `Header`
+
+## Contexto
+
+O header já possui um `div` placeholder circular (w-9 h-9) onde a foto de perfil deve aparecer. O projeto usa NextAuth v4 com `GoogleProvider` e sessão JWT — `session.user.image` é populado automaticamente pelo NextAuth a partir do perfil Google, sem callbacks extras. Para usuários que entraram por email/código, `session.user.image` é `null`. O projeto já possui `Avatar / AvatarImage / AvatarFallback` de `@radix-ui/react-avatar` em `src/components/ui/avatar.tsx`.
+
+## Fluxo da Imagem
+
+1. Usuário faz login via Google OAuth
+2. Google retorna o perfil com a URL da foto (`picture`, domínio `lh3.googleusercontent.com`)
+3. NextAuth salva a URL no JWT como `token.picture`
+4. `useSession()` expõe `session.user.image` com essa URL
+5. `UserAvatar` recebe `image` como prop e renderiza via `AvatarImage`
+6. Se `image` for `null` ou a carga falhar → Radix exibe `AvatarFallback` com as iniciais
+
+Para usuários email/código, `session.user.image` é `null` e o fallback de iniciais é exibido diretamente.
+
+## Componente `UserAvatar`
+
+**Arquivo:** `src/components/user-avatar.tsx`
+
+Props:
+- `name?: string | null`
+- `email?: string | null`
+- `image?: string | null`
+
+**Lógica de iniciais:**
+- Se `name` existir: primeira letra da primeira palavra + primeira letra da última palavra.  
+  Ex: `"Fernando Meira"` → `FM`, `"Fernando"` → `F`
+- Se não houver `name`: primeira letra do maior trecho do email via `getBiggestUsernamePart` (utilitário já existente em `src/utils`)
+
+**Estilo:**
+- Tamanho: `w-9 h-9` (igual ao placeholder atual)
+- Borda: `border border-[var(--color-hairline)]`
+- Fallback: texto de iniciais com `text-xs font-semibold text-[var(--color-muted)]` sobre fundo `bg-[var(--color-surface-card)]`
+
+## Integração no `Header`
+
+O `div` placeholder atual (linha 31 de `src/components/header.tsx`) é substituído por:
+
+```tsx
+<UserAvatar
+  name={session?.user?.name}
+  email={session?.user?.email}
+  image={session?.user?.image}
+/>
+```
+
+Nenhuma outra alteração no header é necessária.
+
+## Arquivos Alterados
+
+- **Novo:** `src/components/user-avatar.tsx`
+- **Modificado:** `src/components/header.tsx` — substituir `div` placeholder por `<UserAvatar />`
+
+## Sem Mudanças Necessárias
+
+- `src/lib/auth.ts` — `session.user.image` já é provido pelo NextAuth automaticamente
+- `next.config.js` — Radix UI usa `<img>` nativo, não `next/image`; nenhuma configuração de domínio externo necessária
+
+## Verificação
+
+Após implementar:
+
+- `npm run lint`
+- `npx tsc --noEmit`
+
+Validar manualmente:
+- Usuário Google: foto de perfil aparece no avatar do header
+- Usuário email/código: iniciais aparecem no avatar do header
+- Imagem indisponível (URL inválida): fallback de iniciais exibido pelo Radix

--- a/src/components/category-hero-card.tsx
+++ b/src/components/category-hero-card.tsx
@@ -13,9 +13,9 @@ interface StatPillProps {
 
 function StatPill({ value, label }: StatPillProps) {
   return (
-    <div className="flex flex-1 items-center gap-1.5 rounded-full bg-[var(--color-surface-dark)] px-3 py-[9px]">
-      <span className="text-[13px] font-medium text-[var(--color-on-dark)]">{value}</span>
-      <span className="text-[13px] font-medium text-[var(--color-on-dark-soft)]">{label}</span>
+    <div className="flex flex-1 items-center gap-1.5 rounded-full bg-[var(--color-surface-soft)] px-3 py-[9px]">
+      <span className="text-[13px] font-medium text-[var(--color-ink)]">{value}</span>
+      <span className="text-[13px] font-medium text-[var(--color-muted)]">{label}</span>
     </div>
   );
 }
@@ -31,23 +31,23 @@ export function CategoryHeroCard({ category, products }: CategoryHeroCardProps) 
   const totalCount = products.length;
 
   return (
-    <div className="flex flex-col gap-3.5 rounded-[var(--radius-xl)] border border-[var(--color-surface-dark-elevated)] bg-[var(--color-surface-dark-elevated)] p-[18px] [font-family:var(--font-body)]">
+    <div className="flex flex-col gap-3.5 rounded-[var(--radius-xl)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] p-[18px] [font-family:var(--font-body)]">
       <div className="flex flex-col gap-2.5">
         <div className="flex flex-col gap-1">
           {/* Hero title */}
-          <h1 className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-[var(--color-on-dark)] [font-family:var(--font-display)]">
+          <h1 className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-[var(--color-ink)] [font-family:var(--font-display)]">
             {category.name}
           </h1>
 
           {/* Subtitle */}
-          <p className="text-[13px] font-medium text-[var(--color-on-dark-soft)]">
+          <p className="text-[13px] font-medium text-[var(--color-muted)]">
             {totalCount} produto{totalCount !== 1 ? 's' : ''} nesta lista
           </p>
         </div>
 
-        <div className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[var(--color-surface-dark)] px-2.5 py-2">
+        <div className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[var(--color-surface-soft)] px-2.5 py-2">
           <ShoppingCart className="h-3.5 w-3.5 text-[var(--color-success)]" />
-          <span className="text-[13px] font-medium text-[var(--color-on-dark)]">
+          <span className="text-[13px] font-medium text-[var(--color-ink)]">
             {cartCount} no carrinho
           </span>
         </div>

--- a/src/components/category-select.tsx
+++ b/src/components/category-select.tsx
@@ -20,17 +20,17 @@ export function CategorySelect() {
 
   return (
     <Select value={selectedCategoryId || ''} onValueChange={handleCategoryChange}>
-      <SelectTrigger className="flex h-16 w-full items-center justify-between rounded-[var(--radius-md)] border border-[var(--color-surface-dark-elevated)] bg-[var(--color-surface-dark)] px-[14px] py-[13px] shadow-none [&>svg]:hidden">
+      <SelectTrigger className="flex h-16 w-full items-center justify-between rounded-[var(--radius-md)] border border-[var(--color-hairline)] bg-[var(--color-surface-card)] px-[14px] py-[13px] shadow-none [&>svg]:hidden">
         <div className="flex flex-col gap-[3px]">
-          <span className="text-[10px] font-bold leading-none text-[var(--color-on-dark-soft)]">
+          <span className="text-[10px] font-bold leading-none text-[var(--color-muted)]">
             Lista atual
           </span>
-          <span className="text-[14px] font-semibold leading-[1.15] text-[var(--color-on-dark)]">
+          <span className="text-[14px] font-semibold leading-[1.15] text-[var(--color-ink)]">
             {selectedName}
           </span>
         </div>
         <span className="flex shrink-0 items-center">
-          <ChevronDown className="h-[18px] w-[18px] text-[var(--color-on-dark)]" />
+          <ChevronDown className="h-[18px] w-[18px] text-[var(--color-ink)]" />
         </span>
       </SelectTrigger>
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -7,6 +7,7 @@ import { signOut, useSession } from 'next-auth/react';
 import { Sun, Moon, LogIn, LogOut, ShoppingBasket } from 'lucide-react';
 
 import { PagesEnum } from '@/types/enums';
+import { UserAvatar } from '@/components/user-avatar';
 
 export function Header() {
   const { data: session } = useSession();
@@ -28,7 +29,11 @@ export function Header() {
     <header className="fixed top-0 left-0 right-0 z-10 flex items-center justify-between h-14 px-3 bg-[var(--color-canvas)] border-b border-[var(--color-hairline)] max-w-3xl mx-auto">
       {isLoggedIn ? (
         <div className="flex items-center gap-2">
-          <div className="w-9 h-9 rounded-full bg-[var(--color-surface-card)] border border-[var(--color-hairline)] flex-shrink-0" />
+          <UserAvatar
+            name={session?.user?.name}
+            email={session?.user?.email}
+            image={session?.user?.image}
+          />
           <div className="flex flex-col gap-0.5">
             <span className="text-[13px] font-semibold leading-none text-[var(--color-ink)]">
               Olá, {firstName}

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { getBiggestUsernamePart } from '@/utils';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 
 interface UserAvatarProps {
   name?: string | null;
@@ -11,9 +11,14 @@ interface UserAvatarProps {
 
 function getInitials(name?: string | null, email?: string | null): string {
   if (name) {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length === 1) return parts[0][0].toUpperCase();
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) {
+      // fall through to email fallback
+    } else if (parts.length === 1) {
+      return parts[0][0].toUpperCase();
+    } else {
+      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    }
   }
   if (email) {
     const part = getBiggestUsernamePart(email);

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -12,9 +12,7 @@ interface UserAvatarProps {
 function getInitials(name?: string | null, email?: string | null): string {
   if (name) {
     const parts = name.trim().split(/\s+/).filter(Boolean);
-    if (parts.length === 0) {
-      // fall through to email fallback
-    } else if (parts.length === 1) {
+    if (parts.length === 1) {
       return parts[0][0].toUpperCase();
     } else {
       return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { getBiggestUsernamePart } from '@/utils';
+
+interface UserAvatarProps {
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+}
+
+function getInitials(name?: string | null, email?: string | null): string {
+  if (name) {
+    const parts = name.trim().split(/\s+/);
+    if (parts.length === 1) return parts[0][0].toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+  if (email) {
+    const part = getBiggestUsernamePart(email);
+    return part ? part[0].toUpperCase() : '';
+  }
+  return '';
+}
+
+export function UserAvatar({ name, email, image }: UserAvatarProps) {
+  const initials = getInitials(name, email);
+
+  return (
+    <Avatar className="w-9 h-9 border border-[var(--color-hairline)]">
+      <AvatarImage src={image ?? undefined} alt={name ?? email ?? 'Avatar'} />
+      <AvatarFallback className="bg-[var(--color-surface-card)] text-xs font-semibold text-[var(--color-muted)]">
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  );
+}


### PR DESCRIPTION
## Summary

- Cria o componente `UserAvatar` (`src/components/user-avatar.tsx`) que exibe a foto de perfil do Google via Radix UI `Avatar/AvatarImage/AvatarFallback`
- Implementa fallback de iniciais: primeira + última inicial do nome, ou inicial do trecho mais relevante do email via `getBiggestUsernamePart`
- Substitui o `div` placeholder no `Header` pelo novo componente, recebendo `name`, `email` e `image` diretamente da sessão NextAuth

## Test Plan

- [ ] Login com Google: foto de perfil aparece no avatar do header
- [ ] Login com email/código: iniciais aparecem no avatar (ex: `FM` para "Fernando Meira")
- [ ] Imagem indisponível (URL inválida ou expirada): Radix exibe o fallback de iniciais automaticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)