### PR TITLE
feat: add collapsible toggle to category hero card

### DIFF
--- a/docs/superpowers/plans/2026-06-06-pencil-collapsible-category-hero.md
+++ b/docs/superpowers/plans/2026-06-06-pencil-collapsible-category-hero.md
@@ -1,0 +1,58 @@
+# Pencil Collapsible Category Hero Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the Pencil category hero to communicate an expandable/collapsible state and add the collapsed variant to the reusable components frame.
+
+**Architecture:** Make the smallest visual edits directly in `EasyList.pen`: add collapse affordances to existing light and dark hero cards, then update the reusable component sample and add a closed-state reusable variant. Pencil has no runtime interaction, so the design documents the interaction through visible expanded and collapsed states.
+
+**Tech Stack:** Pencil MCP, `.pen` design schema, existing EasyList design components.
+
+---
+
+### Task 1: Update Page Hero Cards
+
+**Files:**
+- Modify: `/C:/Users/ThomW/OneDrive/Documentos/Design Pencil/EasyList/EasyList.pen`
+
+- [ ] **Step 1: Add a collapse affordance to light mode**
+
+Use `batch_design` to insert a small circular chevron-up control into `m3lcaq`, preserving title, subtitle, and cart badge.
+
+- [ ] **Step 2: Add a collapse affordance to dark mode**
+
+Use `batch_design` to insert the matching dark-mode chevron-up control into `aufqa`.
+
+- [ ] **Step 3: Verify page layouts**
+
+Run `snapshot_layout` on `b397K` and `aPIpx`; expected result: no clipping, hero card remains aligned, and content below shifts consistently if card height changes.
+
+### Task 2: Update Reusable Components Frame
+
+**Files:**
+- Modify: `/C:/Users/ThomW/OneDrive/Documentos/Design Pencil/EasyList/EasyList.pen`
+
+- [ ] **Step 1: Update the expanded reusable hero component sample**
+
+Replace `E1xhtT` with a structure matching the current expanded hero model: title row, cart badge, collapse affordance, stats, and selector field.
+
+- [ ] **Step 2: Add a collapsed reusable hero variant**
+
+Insert a new reusable component below `E1xhtT` in `Category Page - Reusable Components`. The variant shows only the title, subtitle, cart badge, and a chevron-down affordance.
+
+- [ ] **Step 3: Verify reusable components layout**
+
+Run `snapshot_layout` on `m58G8L`; expected result: both hero examples are visible and the frame is tall enough for the new component.
+
+### Task 3: Visual QA
+
+**Files:**
+- Modify: `/C:/Users/ThomW/OneDrive/Documentos/Design Pencil/EasyList/EasyList.pen`
+
+- [ ] **Step 1: Check layout problems**
+
+Run `snapshot_layout` with `problemsOnly: true` on `b397K`, `aPIpx`, and `m58G8L`; expected result: no clipped or collapsed nodes caused by the update.
+
+- [ ] **Step 2: Inspect screenshots if needed**
+
+Use `get_screenshot` only if layout data suggests a visual issue.

--- a/docs/superpowers/specs/2026-06-06-pencil-collapsible-category-hero-design.md
+++ b/docs/superpowers/specs/2026-06-06-pencil-collapsible-category-hero-design.md
@@ -1,0 +1,23 @@
+# Pencil Collapsible Category Hero Design
+
+## Context
+
+The Pencil file `EasyList.pen` contains a category page hero card in light mode (`zt4EJ`), a matching dark mode hero card (`qklHM`), and a reusable component sample in `Category Page - Reusable Components` (`E1xhtT`). The collapsed state should show only the information currently present in `m3lcaq`: title, subtitle, and cart summary badge.
+
+## Approved Approach
+
+Keep the expanded hero card in the page flow, add a clear collapse affordance to the hero header, and update the reusable components frame with a collapsed variant that documents the closed state.
+
+## Design Requirements
+
+- The expanded hero remains visually compatible with the current mobile category page.
+- The closed state contains only the `m3lcaq` information: category title, product count subtitle, and cart badge.
+- The collapse affordance is visible in light and dark mode.
+- The reusable components frame includes the updated expandable hero component and a closed-state variant.
+- Existing spacing, typography, Portuguese-facing copy, and current visual language are preserved.
+
+## Validation
+
+- Check light and dark page layouts for clipping or broken alignment.
+- Check the reusable components frame for visible updated component examples.
+- Ensure text contrast remains sufficient in both themes.

--- a/src/app/api/auth/request-code/route.ts
+++ b/src/app/api/auth/request-code/route.ts
@@ -115,8 +115,6 @@ export async function POST(request: Request) {
         console.error('Erro do Resend ao enviar email:', emailResult.error);
         throw new Error(`Falha ao enviar email: ${emailResult.error.message}`);
       }
-
-      console.log('Email enviado com sucesso:', emailResult.data);
     } catch (emailError) {
       logEmailError('Falha ao enviar código de acesso', emailError, {
         to: email,

--- a/src/app/api/auth/send-login/route.ts
+++ b/src/app/api/auth/send-login/route.ts
@@ -51,7 +51,6 @@ export async function POST(request: Request) {
     const { email } = result.data;
 
     const emailConfig = validateEmailConfig({ requireBaseUrl: true });
-    console.log('🥲 ~ emailConfig:', emailConfig);
 
     if (!emailConfig.isValid) {
       console.error('Configuração de email inválida', {
@@ -167,8 +166,6 @@ export async function POST(request: Request) {
         console.error('Erro do Resend ao enviar email:', emailResult.error);
         throw new Error(`Falha ao enviar email: ${emailResult.error.message}`);
       }
-
-      console.log('Email enviado com sucesso:', emailResult.data);
     } catch (emailError) {
       logEmailError('Falha ao enviar login email', emailError, {
         to: email,

--- a/src/components/category-hero-card.tsx
+++ b/src/components/category-hero-card.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { ShoppingCart } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronUp, ChevronDown, ShoppingCart } from 'lucide-react';
 
 import { ProductProps, CategoryProps } from '@/types/interfaces';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 
 import { CategorySelect } from './category-select';
 
@@ -26,20 +28,24 @@ interface CategoryHeroCardProps {
 }
 
 export function CategoryHeroCard({ category, products }: CategoryHeroCardProps) {
+  const [isOpen, setIsOpen] = useState(true);
   const pendingCount = products.filter(p => !p.addToCart).length;
   const cartCount = products.filter(p => p.addToCart).length;
   const totalCount = products.length;
+  const toggleLabel = isOpen ? 'Recolher detalhes da categoria' : 'Expandir detalhes da categoria';
 
   return (
-    <div className="flex flex-col gap-3.5 rounded-[var(--radius-xl)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] p-[18px] [font-family:var(--font-body)]">
-      <div className="flex flex-col gap-2.5">
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="flex flex-col gap-3.5 rounded-[var(--radius-xl)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] p-[18px] [font-family:var(--font-body)]"
+    >
+      <div className="relative flex flex-col gap-2.5 pr-10">
         <div className="flex flex-col gap-1">
-          {/* Hero title */}
           <h1 className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-[var(--color-ink)] [font-family:var(--font-display)]">
             {category.name}
           </h1>
 
-          {/* Subtitle */}
           <p className="text-[13px] font-medium text-[var(--color-muted)]">
             {totalCount} produto{totalCount !== 1 ? 's' : ''} nesta lista
           </p>
@@ -51,16 +57,27 @@ export function CategoryHeroCard({ category, products }: CategoryHeroCardProps) 
             {cartCount} no carrinho
           </span>
         </div>
+
+        <CollapsibleTrigger
+          className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center rounded-full border border-[var(--color-hairline)] bg-[var(--color-surface-soft)] text-[var(--color-ink)] transition-colors hover:bg-[var(--color-surface-card)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ink)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-canvas)]"
+          aria-label={toggleLabel}
+        >
+          {isOpen ? (
+            <ChevronUp className="h-4 w-4" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-4 w-4" aria-hidden="true" />
+          )}
+        </CollapsibleTrigger>
       </div>
 
-      {/* Stat pills */}
-      <div className="flex w-full gap-2.5">
-        <StatPill value={pendingCount} label="pendentes" />
-        <StatPill value={cartCount} label="comprados" />
-      </div>
+      <CollapsibleContent className="flex flex-col gap-3.5">
+        <div className="flex w-full gap-2.5">
+          <StatPill value={pendingCount} label="pendentes" />
+          <StatPill value={cartCount} label="comprados" />
+        </div>
 
-      {/* Category selector */}
-      <CategorySelect />
-    </div>
+        <CategorySelect />
+      </CollapsibleContent>
+    </Collapsible>
   );
 }


### PR DESCRIPTION
## Summary

- Adiciona toggle colapsável ao `CategoryHeroCard` — os stat pills e o seletor de categoria podem ser recolhidos/expandidos via botão chevron
- Remove `console.log` de debug das rotas `request-code` e `send-login`

## Test Plan

- [ ] Abrir uma categoria — hero card começa expandido
- [ ] Clicar no botão chevron — stat pills e category select recolhem
- [ ] Clicar novamente — expande de volta
- [ ] Verificar acessibilidade: `aria-label` do botão muda entre "Recolher" e "Expandir"

🤖 Generated with [Claude Code](https://claude.com/claude-code)