### PR TITLE
feat: redesign category drawers with Vaul bottom sheet

### DIFF
--- a/docs/superpowers/plans/2026-06-06-category-drawer-redesign.md
+++ b/docs/superpowers/plans/2026-06-06-category-drawer-redesign.md
@@ -1,0 +1,382 @@
+# Category Drawer Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Substituir o wrapper `DrawerContent` por `DrawerPrimitive` (Vaul) nos dois drawers de categoria, aplicar a linguagem visual do `ProductManagerSheet`, e extrair o trigger do `NewCategoryDrawer` para o `footer.tsx`.
+
+**Architecture:** Dois componentes modificados (`new-category-drawer.tsx` e `confirm-remove-category-drawer.tsx`) + um consumidor atualizado (`footer.tsx`). Nenhum arquivo novo. A interface de props do `ConfirmRemoveCategoryDrawer` permanece idêntica; o `NewCategoryDrawer` passa a aceitar `open`/`onOpenChange` em vez de gerenciar seu próprio estado.
+
+**Tech Stack:** Next.js 15, TypeScript, Tailwind CSS, Vaul (`vaul` — já instalado), react-hook-form, lucide-react.
+
+---
+
+## Contexto de referência
+
+```ts
+// src/types/interfaces.ts
+interface CategoryProps {
+  _id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  products?: ProductProps[];
+}
+```
+
+```ts
+// src/context/CategoryContext.tsx — hooks relevantes
+const { addCategory } = useCategories();     // POST /api/categories
+const { removeCategory } = useCategories();  // DELETE /api/categories?id=${id}
+```
+
+```ts
+// src/lib/utils.ts
+export function cn(...inputs: ClassValue[]): string  // clsx + twMerge
+```
+
+O `Drawer as DrawerPrimitive` vem de `'vaul'` — mesmo import usado em `product-manager-sheet.tsx`.
+
+**Base SHA para revisões de código:** `8dc823a` (commit do spec)
+
+---
+
+## Mapa de arquivos
+
+| Ação | Arquivo |
+|---|---|
+| Modificar | `src/components/new-category-drawer.tsx` |
+| Modificar | `src/components/footer.tsx` |
+| Modificar | `src/components/confirm-remove-category-drawer.tsx` |
+
+---
+
+## Task 1: Redesign `NewCategoryDrawer` + atualizar `footer.tsx`
+
+**Files:**
+- Modify: `src/components/new-category-drawer.tsx`
+- Modify: `src/components/footer.tsx`
+
+- [ ] **Step 1: Substituir `new-category-drawer.tsx` completamente**
+
+```tsx
+// src/components/new-category-drawer.tsx
+'use client';
+
+import { X, Plus } from 'lucide-react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+import { useForm, FormProvider } from 'react-hook-form';
+
+import { cn } from '@/lib/utils';
+import { useCategories } from '@/context';
+import { Input } from '@/components/ui/input';
+import { CategoryProps } from '@/types/interfaces';
+
+interface NewCategoryDrawerProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function NewCategoryDrawer({ open, onOpenChange }: NewCategoryDrawerProps) {
+  const { addCategory } = useCategories();
+
+  const methods = useForm<CategoryProps>({
+    defaultValues: {
+      name: '',
+    },
+  });
+
+  const onSubmit = methods.handleSubmit((data) => {
+    addCategory(data);
+    methods.reset();
+    onOpenChange?.(false);
+  });
+
+  return (
+    <DrawerPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DrawerPrimitive.Portal>
+        <DrawerPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60" />
+
+        <DrawerPrimitive.Content
+          className={cn(
+            'fixed inset-x-0 bottom-0 z-50 flex flex-col',
+            'rounded-t-2xl bg-background outline-none',
+            'shadow-[0_-4px_12px_rgba(0,0,0,0.08)]'
+          )}
+        >
+          <div className="flex flex-shrink-0 justify-center pt-2.5">
+            <div className="h-[5px] w-11 rounded-full bg-[#d1d5db]" />
+          </div>
+
+          <div className="flex flex-col gap-4 px-5 pb-4 pt-4">
+            <div className="flex items-start justify-between">
+              <div className="flex flex-1 flex-col gap-1 pr-3">
+                <DrawerPrimitive.Title className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-foreground">
+                  Nova categoria
+                </DrawerPrimitive.Title>
+                <DrawerPrimitive.Description className="text-sm leading-[1.5] text-[#374151] dark:text-[#a1a1aa]">
+                  Digite o nome e a categoria fica disponível imediatamente.
+                </DrawerPrimitive.Description>
+              </div>
+
+              <button
+                type="button"
+                aria-label="Fechar"
+                onClick={() => onOpenChange?.(false)}
+                className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-white dark:border-[#242424] dark:bg-[#101010]"
+              >
+                <X className="h-5 w-5 text-foreground" />
+              </button>
+            </div>
+
+            <FormProvider {...methods}>
+              <form onSubmit={onSubmit} className="flex flex-col gap-4">
+                <div className="flex flex-col gap-[7px]">
+                  <span className="text-[13px] font-bold leading-[1.35] text-foreground">
+                    Categoria
+                  </span>
+                  <Input
+                    required
+                    id="name"
+                    type="text"
+                    placeholder="Nome da categoria"
+                    className="h-10 rounded-lg px-3.5 text-base font-semibold"
+                    {...methods.register('name')}
+                  />
+                </div>
+
+                <div className="flex flex-col gap-2.5">
+                  <button
+                    type="submit"
+                    className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-foreground text-sm font-semibold text-background"
+                  >
+                    <Plus className="h-5 w-5" />
+                    Criar categoria
+                  </button>
+
+                  <p className="text-[13px] font-medium leading-[1.4] text-[#898989]">
+                    Enter também cria quando o nome estiver preenchido.
+                  </p>
+                </div>
+              </form>
+            </FormProvider>
+          </div>
+        </DrawerPrimitive.Content>
+      </DrawerPrimitive.Portal>
+    </DrawerPrimitive.Root>
+  );
+}
+```
+
+- [ ] **Step 2: Atualizar `footer.tsx` — mover trigger e gerenciar estado**
+
+```tsx
+// src/components/footer.tsx
+'use client';
+
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+
+import { PagesEnum } from '@/types/enums';
+import { convertToCurrency } from '@/utils';
+import { calculateTotalValue } from '@/utils';
+import { useProducts } from '@/context/ProductContext';
+
+import { NewProductForm } from './new-product-form';
+import { NewCategoryDrawer } from './new-category-drawer';
+
+export function Footer() {
+  const pathname = usePathname();
+  const { products, allProductsWithoutPrice, allProductsInCartWithoutPrice } = useProducts();
+  const [categoryDrawerOpen, setCategoryDrawerOpen] = useState(false);
+
+  const isHomePage = pathname === PagesEnum.home;
+  const shouldRenderPrice = !!products && !isHomePage && (!allProductsWithoutPrice || !allProductsInCartWithoutPrice);
+
+  return (
+    <footer className={'fixed bottom-0 w-full m-auto rounded-t-sm max-w-3xl bg-white dark:bg-background'}>
+      {shouldRenderPrice && (
+        <div className="p-4 flex justify-between gap-4 mx-auto">
+          {!allProductsWithoutPrice && (
+            <p className="font-semibold">Total: {convertToCurrency(calculateTotalValue(products).totalProductsValue)}</p>
+          )}
+
+          {!allProductsInCartWithoutPrice && (
+            <p className="font-semibold text-teal-400">Carrinho: {convertToCurrency(calculateTotalValue(products).filteredProductsValue)}</p>
+          )}
+        </div>
+      )}
+
+      <div className={isHomePage ? 'w-full p-4' : 'flex items-center gap-2'}>
+        {!isHomePage ? (
+          <NewProductForm />
+        ) : (
+          <>
+            <button
+              onClick={() => setCategoryDrawerOpen(true)}
+              className="flex h-12 w-full items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)] transition-opacity hover:opacity-90 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)]"
+              aria-label="Adicionar categoria"
+            >
+              <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
+              <span className="text-sm font-semibold text-[var(--color-on-primary)]">
+                Adicionar categoria
+              </span>
+            </button>
+
+            <NewCategoryDrawer open={categoryDrawerOpen} onOpenChange={setCategoryDrawerOpen} />
+          </>
+        )}
+      </div>
+    </footer>
+  );
+}
+```
+
+- [ ] **Step 3: Checar tipos**
+
+```powershell
+npx tsc --noEmit
+```
+
+Esperado: sem erros.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/new-category-drawer.tsx src/components/footer.tsx
+git commit -m "feat: redesign NewCategoryDrawer with Vaul bottom sheet and extract trigger to footer"
+```
+
+---
+
+## Task 2: Redesign `ConfirmRemoveCategoryDrawer`
+
+**Files:**
+- Modify: `src/components/confirm-remove-category-drawer.tsx`
+
+- [ ] **Step 1: Substituir `confirm-remove-category-drawer.tsx` completamente**
+
+A interface de props **não muda** — apenas o visual. Nenhum ajuste necessário nos consumidores.
+
+```tsx
+// src/components/confirm-remove-category-drawer.tsx
+'use client';
+
+import { toast } from 'sonner';
+import { X, Trash } from 'lucide-react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+import { cn } from '@/lib/utils';
+import { useCategories } from '@/context';
+import { CategoryProps } from '@/types/interfaces';
+
+interface ConfirmRemoveCategoryDrawerProps {
+  open: boolean;
+  category?: CategoryProps;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ConfirmRemoveCategoryDrawer({ category, open, onOpenChange }: ConfirmRemoveCategoryDrawerProps) {
+  const { removeCategory } = useCategories();
+
+  const handleRemoveCategory = () => {
+    if (!category) {
+      toast('Categoria não encontrada');
+      return;
+    }
+
+    removeCategory(category._id);
+    onOpenChange(false);
+  };
+
+  if (!category) return null;
+
+  return (
+    <DrawerPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DrawerPrimitive.Portal>
+        <DrawerPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60" />
+
+        <DrawerPrimitive.Content
+          className={cn(
+            'fixed inset-x-0 bottom-0 z-50 flex flex-col',
+            'rounded-t-2xl bg-background outline-none',
+            'shadow-[0_-4px_12px_rgba(0,0,0,0.08)]'
+          )}
+        >
+          <div className="flex flex-shrink-0 justify-center pt-2.5">
+            <div className="h-[5px] w-11 rounded-full bg-[#d1d5db]" />
+          </div>
+
+          <div className="flex flex-col gap-4 px-5 pb-4 pt-4">
+            <div className="flex items-start justify-between">
+              <div className="flex flex-1 flex-col gap-1 pr-3">
+                <DrawerPrimitive.Title className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-foreground">
+                  {category.name}
+                </DrawerPrimitive.Title>
+                <DrawerPrimitive.Description className="text-sm leading-[1.5] text-[#374151] dark:text-[#a1a1aa]">
+                  Tem certeza que deseja remover esta categoria?
+                </DrawerPrimitive.Description>
+              </div>
+
+              <button
+                type="button"
+                aria-label="Fechar"
+                onClick={() => onOpenChange(false)}
+                className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-white dark:border-[#242424] dark:bg-[#101010]"
+              >
+                <X className="h-5 w-5 text-foreground" />
+              </button>
+            </div>
+
+            <div className="rounded-xl border border-border bg-[#f5f5f5] p-3 dark:border-[#242424] dark:bg-[#1a1a1a]">
+              <p className="text-sm font-medium text-foreground">
+                Esta ação não pode ser desfeita.
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleRemoveCategory}
+              className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-error)] text-sm font-semibold text-white"
+            >
+              <Trash className="h-5 w-5" />
+              Remover {category.name}
+            </button>
+          </div>
+        </DrawerPrimitive.Content>
+      </DrawerPrimitive.Portal>
+    </DrawerPrimitive.Root>
+  );
+}
+```
+
+- [ ] **Step 2: Checar tipos**
+
+```powershell
+npx tsc --noEmit
+```
+
+Esperado: sem erros.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/confirm-remove-category-drawer.tsx
+git commit -m "feat: redesign ConfirmRemoveCategoryDrawer with Vaul bottom sheet"
+```
+
+---
+
+## Checklist de conclusão
+
+- [ ] `NewCategoryDrawer` não tem mais trigger interno nem estado `open` próprio
+- [ ] Botão "Adicionar categoria" em `footer.tsx` abre o drawer corretamente
+- [ ] Bottom sheet de criação sobe da base, tem drag handle, botão X fecha
+- [ ] Título "Nova categoria" em Cal Sans 28px (font-sans padrão do projeto)
+- [ ] Campo de nome submete com Enter (comportamento nativo do `<form>`)
+- [ ] `ConfirmRemoveCategoryDrawer` usa `DrawerPrimitive` com nova linguagem visual
+- [ ] Título do drawer de exclusão exibe o nome da categoria em Cal Sans 28px
+- [ ] Card de aviso "Esta ação não pode ser desfeita." visível
+- [ ] Botão de exclusão vermelho (`--color-error`)
+- [ ] Dark mode correto em ambos os drawers
+- [ ] `npx tsc --noEmit` passa sem erros

--- a/docs/superpowers/specs/2026-06-06-category-drawer-redesign.md
+++ b/docs/superpowers/specs/2026-06-06-category-drawer-redesign.md
@@ -1,0 +1,192 @@
+# Category Drawer Redesign — Spec
+
+**Data:** 2026-06-06  
+**Branch:** feat/modals  
+**Referência:** `ProductManagerSheet` redesign (PR #68)
+
+---
+
+## Contexto
+
+Os drawers de criação e confirmação de exclusão de categorias usam o wrapper `DrawerContent` de `@/components/ui/drawer`, que não segue o padrão visual adotado no redesign do `ProductManagerSheet` (Vaul `DrawerPrimitive` direto, Cal Sans, drag handle, botão X circular). Este redesign alinha os dois componentes com esse padrão sem adicionar funcionalidades novas.
+
+---
+
+## Objetivo
+
+Substituir o wrapper `DrawerContent` por `DrawerPrimitive` direto nos dois componentes de categoria, aplicar a linguagem visual do novo `ProductManagerSheet`, e extrair o trigger do `NewCategoryDrawer` para o componente pai.
+
+---
+
+## Escopo
+
+### Arquivos modificados
+
+| Arquivo | Mudança |
+|---|---|
+| `src/components/new-category-drawer.tsx` | Remover trigger interno → aceitar `open`/`onOpenChange` → trocar wrapper por `DrawerPrimitive` → nova linguagem visual |
+| `src/components/confirm-remove-category-drawer.tsx` | Somente redesign visual — interface de props não muda |
+| Componente pai do `NewCategoryDrawer` | Mover trigger "Adicionar categoria" para cá, gerenciar estado `open` |
+
+### Sem mudanças
+
+- `src/context/CategoryContext.tsx` — `addCategory`, `removeCategory`
+- `src/types/interfaces.ts` — `CategoryProps`
+- APIs de categoria
+
+---
+
+## Componentes
+
+### `NewCategoryDrawer`
+
+**Interface nova (controlado externamente):**
+
+```tsx
+interface NewCategoryDrawerProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+```
+
+**Estrutura:**
+
+```
+DrawerPrimitive.Root (open, onOpenChange)
+└── DrawerPrimitive.Portal
+    ├── DrawerPrimitive.Overlay    — fixed inset-0 z-50 bg-black/60
+    └── DrawerPrimitive.Content    — fixed inset-x-0 bottom-0 z-50
+                                     rounded-t-2xl bg-background outline-none
+                                     shadow-[0_-4px_12px_rgba(0,0,0,0.08)]
+        ├── Drag handle            — flex justify-center pt-2.5
+        │                            div w-11 h-[5px] rounded-full bg-[#d1d5db]
+        └── div.px-5.pb-4.pt-4.flex.flex-col.gap-4
+            ├── Header             — flex items-start justify-between
+            │   ├── Bloco texto    — flex-col gap-1
+            │   │   ├── Drawer.Title    — "Nova categoria"
+            │   │   └── Drawer.Description — "Digite o nome e a categoria fica disponível imediatamente."
+            │   └── Botão X        — h-9 w-9 rounded-full border border-border
+            │                        flex-shrink-0, aria-label="Fechar"
+            │                        bg-white dark:border-[#242424] dark:bg-[#101010]
+            └── form.flex.flex-col.gap-4
+                ├── Campo Nome
+                │   ├── span "Categoria" — text-[13px] font-bold text-foreground
+                │   └── Input — h-10 rounded-lg px-3.5 text-base font-semibold
+                │               required, placeholder="Nome da categoria"
+                ├── Botão submit   — h-10 w-full rounded-lg bg-foreground text-background
+                │                    text-sm font-semibold, Plus icon + "Criar categoria"
+                └── Helper text   — text-[13px] font-medium text-[#898989]
+                                    "Enter também cria quando o nome estiver preenchido."
+```
+
+**Tipografia:**
+- Título: Cal Sans (`font-sans`), 28px, font-semibold, leading-[1.2], tracking-[-0.5px]
+- Descrição: text-sm, leading-[1.5], text-[#374151] dark:text-[#a1a1aa]
+- Label do campo: text-[13px] font-bold
+- Helper text: text-[13px] font-medium text-[#898989]
+
+**Comportamento:**
+- `onSubmit`: chama `addCategory(data)`, `methods.reset()`, `onOpenChange?.(false)`
+- Enter no campo nome submete o formulário (comportamento nativo do `<form>`)
+
+**Trigger (movido para o pai):**
+
+O botão "Adicionar categoria" que estava dentro do componente é extraído para o componente pai. O pai gerencia `open` e `setOpen`. O botão mantém exatamente o mesmo estilo atual:
+
+```tsx
+<button
+  onClick={() => setOpen(true)}
+  className="flex h-12 w-full items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)] transition-opacity hover:opacity-90 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)]"
+  aria-label="Adicionar categoria"
+>
+  <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
+  <span className="text-sm font-semibold text-[var(--color-on-primary)]">
+    Adicionar categoria
+  </span>
+</button>
+```
+
+---
+
+### `ConfirmRemoveCategoryDrawer`
+
+**Interface — sem mudança:**
+
+```tsx
+interface ConfirmRemoveCategoryDrawerProps {
+  open: boolean;
+  category?: CategoryProps;
+  onOpenChange: (open: boolean) => void;
+}
+```
+
+**Estrutura:**
+
+```
+DrawerPrimitive.Root (open, onOpenChange)
+└── DrawerPrimitive.Portal
+    ├── DrawerPrimitive.Overlay    — fixed inset-0 z-50 bg-black/60
+    └── DrawerPrimitive.Content    — fixed inset-x-0 bottom-0 z-50
+                                     rounded-t-2xl bg-background outline-none
+                                     shadow-[0_-4px_12px_rgba(0,0,0,0.08)]
+        ├── Drag handle            — mesmo padrão do NewCategoryDrawer
+        └── div.px-5.pb-4.pt-4.flex.flex-col.gap-4
+            ├── Header             — flex items-start justify-between
+            │   ├── Bloco texto
+            │   │   ├── Drawer.Title       — category.name (Cal Sans 28px)
+            │   │   └── Drawer.Description — "Tem certeza que deseja remover esta categoria?"
+            │   └── Botão X        — mesmo padrão do NewCategoryDrawer
+            ├── Card de aviso      — rounded-xl bg-[#f5f5f5] dark:bg-[#1a1a1a]
+            │                        border border-border dark:border-[#242424] p-3
+            │                        text-sm font-medium text-foreground
+            │                        "Esta ação não pode ser desfeita."
+            └── Botão de exclusão  — h-10 w-full rounded-lg
+                                     bg-[var(--color-error)] text-white
+                                     text-sm font-semibold
+                                     Trash icon + "Remover [category.name]"
+```
+
+**Comportamento — sem mudança:**
+- `handleRemoveCategory`: chama `removeCategory(category._id)`, `onOpenChange(false)`
+- Toast de erro se `category` for undefined (já existente)
+- Renderização condicional `category &&` mantida
+
+---
+
+## Dark mode
+
+Mesmos tokens do `ProductManagerSheet`:
+
+| Elemento | Light | Dark |
+|---|---|---|
+| Sheet bg | `bg-background` (`#ffffff`) | `bg-background` (`#101010`) |
+| Overlay | `bg-black/60` | `bg-black/60` |
+| Botão X bg | `bg-white` | `dark:bg-[#101010]` |
+| Botão X border | `border-border` | `dark:border-[#242424]` |
+| Card aviso bg | `bg-[#f5f5f5]` | `dark:bg-[#1a1a1a]` |
+| Descrição | `text-[#374151]` | `dark:text-[#a1a1aa]` |
+
+---
+
+## O que não muda
+
+- Lógica de `addCategory` e `removeCategory`
+- Validação (campo `name` obrigatório no `NewCategoryDrawer`)
+- Toast de sucesso/erro (gerenciado pelo `CategoryContext`)
+- `CategoryProps` interface
+- Endpoints de API
+
+---
+
+## Critérios de conclusão
+
+- [ ] `NewCategoryDrawer` aceita `open`/`onOpenChange` e não tem trigger interno
+- [ ] Trigger "Adicionar categoria" funciona no componente pai
+- [ ] Bottom sheet de criação abre/fecha com drag to dismiss
+- [ ] Título "Nova categoria" em Cal Sans 28px
+- [ ] Campo de nome submete com Enter
+- [ ] `ConfirmRemoveCategoryDrawer` usa `DrawerPrimitive` com nova linguagem visual
+- [ ] Título do drawer de exclusão exibe `category.name` em Cal Sans 28px
+- [ ] Card de aviso "Esta ação não pode ser desfeita." visível
+- [ ] Dark mode correto em ambos os drawers
+- [ ] `npx tsc --noEmit` passa sem erros

--- a/docs/superpowers/specs/2026-06-06-firebase-migration-design.md
+++ b/docs/superpowers/specs/2026-06-06-firebase-migration-design.md
@@ -1,0 +1,347 @@
+# Firebase Migration Design
+
+## Context
+
+Easy List is a Next.js 15 App Router application that currently stores application data and auth-related records in MongoDB. Domain data uses Mongoose models for categories and products. Auth uses NextAuth with Google, email magic link, a custom verification-code credentials provider, and `MongoDBAdapter`.
+
+The migration goal is to replace MongoDB with Firebase Firestore while preserving the existing login behavior: Google login, magic link login, and verification-code login remain available and continue using Resend for email delivery.
+
+Existing data does not need to be migrated. The Firebase/Firestore deployment can start empty.
+
+## Goals
+
+- Replace MongoDB and Mongoose persistence with Firestore.
+- Keep NextAuth and the current auth flows working.
+- Keep Resend as the email provider for magic links and verification codes.
+- Keep the existing client API contract as stable as possible.
+- Support Firebase Emulator Suite for local development.
+- Improve product ownership checks while migrating product routes.
+
+## Non-Goals
+
+- Do not migrate to Firebase Auth.
+- Do not migrate existing MongoDB documents into Firestore.
+- Do not redesign the UI or change the user-facing shopping-list flow.
+- Do not replace Resend with a Firebase email service.
+- Do not add a test framework as part of this migration.
+
+## Recommended Approach
+
+Use Firestore server-side through Firebase Admin SDK and use the official Auth.js Firebase adapter for NextAuth persistence.
+
+This keeps the current architecture: client contexts continue calling the same API routes, and the API routes remain the ownership and validation boundary. Firestore is not accessed directly from browser code for categories or products.
+
+Dependencies to add:
+
+```text
+firebase-admin
+@auth/firebase-adapter
+```
+
+Dependencies to remove after migration:
+
+```text
+mongoose
+@types/mongoose
+@auth/mongodb-adapter
+```
+
+## Firebase Admin Setup
+
+Create a server-only Firebase Admin module, likely `src/lib/firebase-admin.ts`, that initializes the default Firebase app once using `getApps()` as a singleton guard.
+
+Production credentials come from environment variables:
+
+```text
+AUTH_FIREBASE_PROJECT_ID
+AUTH_FIREBASE_CLIENT_EMAIL
+AUTH_FIREBASE_PRIVATE_KEY
+```
+
+Local development uses Firebase Emulator Suite. The app should honor `FIRESTORE_EMULATOR_HOST` when it is set. The Firestore client should be initialized from Firebase Admin and shared by server route handlers.
+
+The private key should normalize escaped newlines, because hosted environments often store it as a single-line variable.
+
+## NextAuth Design
+
+Keep the existing `authOptions` shape and providers:
+
+- `GoogleProvider`
+- `EmailProvider`
+- `CredentialsProvider` with id `verification-code`
+- `session: { strategy: 'jwt' }`
+- existing callbacks for Google profile photo
+- existing custom pages
+
+Replace:
+
+```ts
+MongoDBAdapter(clientPromise)
+```
+
+With:
+
+```ts
+FirestoreAdapter(...)
+```
+
+The Firebase adapter stores NextAuth users, accounts, sessions, and verification tokens in Firestore. Since this app uses JWT sessions, the cookie/session behavior remains primarily JWT-based, but user/account/token persistence moves out of MongoDB.
+
+## Resend And Email
+
+Resend remains the email delivery provider. No Firebase email service is introduced.
+
+Existing environment variables remain required:
+
+```text
+RESEND_API_KEY
+EMAIL_FROM
+NEXTAUTH_URL
+```
+
+The email flow changes only in its persistence layer:
+
+- before sending an email, create the code/token record in Firestore instead of MongoDB;
+- after a Resend failure, delete the just-created Firestore record as rollback;
+- keep the current user-facing email copy unless a separate redesign is requested.
+
+`NEXTAUTH_URL` remains required because magic links depend on the correct base URL.
+
+## Firestore Data Model
+
+### `categories/{categoryId}`
+
+```text
+name: string
+userId: string
+createdAt: Timestamp
+updatedAt: Timestamp
+```
+
+Responses should continue exposing `_id` to avoid frontend churn:
+
+```text
+_id = document id
+```
+
+### `products/{productId}`
+
+```text
+name: string
+price?: string | number
+quantity?: string | number
+unit?: string
+categoryId: string
+userId: string
+addToCart: boolean
+createdAt: Timestamp
+updatedAt: Timestamp
+```
+
+Products should include both `categoryId` and `userId`. The current MongoDB product routes do not consistently validate product ownership; this migration should fix that without changing the UI.
+
+### `verificationCodes/{codeRecordId}`
+
+```text
+email: string
+code?: string
+token?: string
+expiresAt: Timestamp
+createdAt: Timestamp
+used: boolean
+usedAt?: Timestamp
+attempts: number
+```
+
+These records support the existing custom code and magic-link endpoints.
+
+### NextAuth Collections
+
+The `FirestoreAdapter` owns its auth collections. The custom verification-code flow is the only planned exception: it may upsert a user record in the same Firestore user collection so `CredentialsProvider.authorize` can return a stable `{ id, email, name }`. The implementation plan must define the exact user fields used for that upsert and avoid writing to adapter-owned account, session, or verification-token collections directly.
+
+## Serialization Contract
+
+The frontend currently expects Mongo-style objects with `_id`, `createdAt`, `updatedAt`, and sometimes embedded `category` objects.
+
+Firestore route handlers should normalize responses into the current shape:
+
+```text
+document id -> _id
+Timestamp -> ISO string
+categoryId -> category reference field for writes
+category -> embedded category object for product responses
+```
+
+This avoids broad changes in `CategoryContext`, `ProductContext`, and UI components.
+
+## API Route Design
+
+### `GET /api/categories`
+
+- Require `getToken` with `authSecret`.
+- Query categories where `userId == token.sub`.
+- If none exist, create the default `Supermercado` category.
+- Query products for the same `userId` and group by `categoryId`.
+- Return categories with embedded `products`, matching the current API response shape.
+
+### `GET /api/categories?id=<categoryId>`
+
+- Require authentication.
+- Fetch the category by document ID.
+- Return `404` if missing or if `userId` does not match `token.sub`.
+- Query products by `userId` and `categoryId`.
+- Return the category with embedded products.
+
+### `POST /api/categories`
+
+- Require authentication.
+- Validate `name`.
+- Create the category with `userId`, `createdAt`, and `updatedAt`.
+- Return `{ data: category }` with `_id` and ISO timestamps.
+
+### `DELETE /api/categories?id=<categoryId>`
+
+- Require authentication.
+- Validate category ownership.
+- Delete associated products and the category in a batch.
+- Return `204` on success.
+
+### `GET /api/products`
+
+- Require authentication and return only products for `token.sub`.
+- Preserve response compatibility by embedding each product's category.
+
+### `POST /api/products`
+
+- Require authentication.
+- Validate `categoryId` belongs to `token.sub`.
+- Create product with `userId`, `categoryId`, `addToCart`, `createdAt`, and `updatedAt`.
+- Return product with embedded `category`.
+
+### `GET /api/products/[id]`
+
+- Require authentication.
+- Fetch product by ID.
+- Return `404` if missing or if `userId` does not match `token.sub`.
+- Return product with embedded `category`.
+
+### `PUT /api/products/[id]`
+
+- Require authentication.
+- Fetch product by ID and validate `userId`.
+- If `categoryId` changes, validate the new category belongs to the same user.
+- Update fields and `updatedAt`.
+- Return product with embedded `category`.
+
+### `DELETE /api/products/[id]`
+
+- Require authentication.
+- Fetch product by ID and validate `userId`.
+- Delete the product.
+- Return the current success response shape.
+
+## Auth Code And Magic Link Routes
+
+### `POST /api/auth/request-code`
+
+- Validate email with Zod.
+- Count recent Firestore `verificationCodes` for that email within the last hour.
+- Enforce the current max-attempts rule.
+- Create a code record in Firestore.
+- Send the code via Resend.
+- If Resend fails, delete the Firestore record and return the existing user-facing error style.
+
+### `POST /api/auth/verify-code`
+
+- Validate email and code.
+- Find an unused, unexpired matching Firestore code record.
+- Increment attempts for invalid known records.
+- Upsert the user record in the Firestore user collection used by NextAuth, preserving a stable user id for the credentials login.
+- Return `{ success: true, email }` so the frontend can continue signing in through the existing credentials provider flow.
+
+### `CredentialsProvider.authorize`
+
+- Replace MongoDB lookups with Firestore lookups.
+- Validate unused, unexpired code and attempts.
+- Mark the record as used.
+- Return `{ id, email, name }` using the Firestore-backed NextAuth user identity.
+
+### `POST /api/auth/send-login`
+
+- Create both code and magic-link token records in Firestore.
+- Send the existing combined login email with Resend.
+- Roll back the Firestore record if Resend fails.
+
+### `GET /api/auth/callback/email`
+
+The current implementation manually creates a session record and cookie while `session.strategy` is `jwt`. For this migration, remove the database-session insert from this custom route. After validating the Firestore magic-link token and upserting the user, issue a NextAuth-compatible JWT session cookie using the existing auth secret and redirect to `/`.
+
+The migration must preserve user behavior: clicking the magic link should authenticate and redirect to `/`.
+
+## Error Handling
+
+Keep Portuguese user-facing errors in API responses and toasts.
+
+Map Firestore/Admin errors to generic user-facing messages similar to the current MongoDB error handling. Avoid leaking Firebase credentials, project IDs, stack traces, or raw service errors to the client.
+
+## Indexes
+
+Expected Firestore query patterns:
+
+- `categories`: `userId`
+- `categories`: `userId`, `name` if category name uniqueness or sorted server queries are added later
+- `products`: `userId`, `categoryId`
+- `verificationCodes`: `email`, `createdAt`
+- `verificationCodes`: `email`, `code`, `used`, `expiresAt`
+- `verificationCodes`: `email`, `token`, `used`, `expiresAt`
+
+Implementation should start with the indexes required by Firestore errors during local/prod verification. Do not add unnecessary composite indexes preemptively beyond queries actually used.
+
+## Local Development
+
+Use Firebase Emulator Suite for Firestore in development.
+
+The implementation plan should add clear setup notes for:
+
+- installing or using Firebase CLI;
+- starting the Firestore emulator;
+- setting `FIRESTORE_EMULATOR_HOST`;
+- preserving Resend variables for real email delivery unless mocked manually by the developer.
+
+## Verification Plan
+
+Automated verification commands:
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm run build
+```
+
+Manual verification checklist:
+
+- Google login works.
+- Magic link email is sent by Resend and authenticates the user.
+- Verification-code email is sent by Resend and authenticates the user.
+- `Supermercado` is created automatically for a new authenticated user.
+- Category creation, listing, and deletion work.
+- Deleting a category deletes its products.
+- Product creation, edit, category move, cart toggle, single deletion, and delete-all flow work.
+- One user's categories/products are not visible or mutable by another user.
+
+## Risks
+
+- The custom magic-link callback currently mixes manual session handling with JWT session strategy. This is the highest-risk part of the migration.
+- Firestore timestamps and document IDs require response normalization to avoid frontend regressions.
+- Firestore query restrictions may require composite indexes discovered during verification.
+- The Firebase adapter's auth collection shape should be treated as adapter-owned to avoid coupling custom code to internals.
+
+## Acceptance Criteria
+
+- The app no longer requires `MONGODB_URI` at module load or runtime.
+- MongoDB and Mongoose imports are removed from application code.
+- NextAuth login via Google, magic link, and code still works.
+- Resend remains responsible for all login emails.
+- Categories and products are persisted in Firestore.
+- Local development can run against Firebase Emulator Suite.
+- Lint, typecheck, and production build pass.

--- a/src/components/confirm-remove-category-drawer.tsx
+++ b/src/components/confirm-remove-category-drawer.tsx
@@ -1,18 +1,12 @@
-import { toast } from 'sonner';
-import { Trash } from 'lucide-react';
+'use client';
 
+import { toast } from 'sonner';
+import { X, Trash } from 'lucide-react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+import { cn } from '@/lib/utils';
 import { useCategories } from '@/context';
 import { CategoryProps } from '@/types/interfaces';
-import {
-  Drawer,
-  DrawerTitle,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerContent,
-  DrawerDescription
-} from '@/components/ui/drawer';
-
-import { ActionButton } from './action-button';
 
 interface ConfirmRemoveCategoryDrawerProps {
   open: boolean;
@@ -23,35 +17,72 @@ interface ConfirmRemoveCategoryDrawerProps {
 export function ConfirmRemoveCategoryDrawer({ category, open, onOpenChange }: ConfirmRemoveCategoryDrawerProps) {
   const { removeCategory } = useCategories();
 
-  const handleRemoveCategory = async () => {
+  const handleRemoveCategory = () => {
     if (!category) {
       toast('Categoria não encontrada');
-
       return;
     }
 
     removeCategory(category._id);
-
     onOpenChange(false);
   };
 
-  return category && (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className='max-w-3xl my-0 mx-auto'>
-        <div className="mx-auto w-full max-w-lg">
-          <DrawerHeader>
-            <DrawerTitle>{category.name}</DrawerTitle>
+  if (!category) return null;
 
-            <DrawerDescription>
-              Tem certeza que deseja remover a categoria {category.name}?
-            </DrawerDescription>
-          </DrawerHeader>
+  return (
+    <DrawerPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DrawerPrimitive.Portal>
+        <DrawerPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60" />
 
-          <DrawerFooter>
-            <ActionButton text={`Remover ${category.name}`} icon={Trash} onClick={handleRemoveCategory} />
-          </DrawerFooter>
-        </div>
-      </DrawerContent>
-    </Drawer>
+        <DrawerPrimitive.Content
+          className={cn(
+            'fixed inset-x-0 bottom-0 z-50 flex flex-col',
+            'rounded-t-2xl bg-background outline-none',
+            'shadow-[0_-4px_12px_rgba(0,0,0,0.08)]'
+          )}
+        >
+          <div className="flex flex-shrink-0 justify-center pt-2.5">
+            <div className="h-[5px] w-11 rounded-full bg-[#d1d5db]" />
+          </div>
+
+          <div className="flex flex-col gap-4 px-5 pb-4 pt-4">
+            <div className="flex items-start justify-between">
+              <div className="flex flex-1 flex-col gap-1 pr-3">
+                <DrawerPrimitive.Title className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-foreground">
+                  {category.name}
+                </DrawerPrimitive.Title>
+                <DrawerPrimitive.Description className="text-sm leading-[1.5] text-[#374151] dark:text-[#a1a1aa]">
+                  Tem certeza que deseja remover esta categoria?
+                </DrawerPrimitive.Description>
+              </div>
+
+              <button
+                type="button"
+                aria-label="Fechar"
+                onClick={() => onOpenChange(false)}
+                className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-white dark:border-[#242424] dark:bg-[#101010]"
+              >
+                <X className="h-5 w-5 text-foreground" />
+              </button>
+            </div>
+
+            <div className="rounded-xl border border-border bg-[#f5f5f5] p-3 dark:border-[#242424] dark:bg-[#1a1a1a]">
+              <p className="text-sm font-medium text-foreground">
+                Esta ação não pode ser desfeita.
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleRemoveCategory}
+              className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-error)] text-sm font-semibold text-white"
+            >
+              <Trash className="h-5 w-5" />
+              Remover {category.name}
+            </button>
+          </div>
+        </DrawerPrimitive.Content>
+      </DrawerPrimitive.Portal>
+    </DrawerPrimitive.Root>
   );
 }

--- a/src/components/confirm-remove-category-drawer.tsx
+++ b/src/components/confirm-remove-category-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { toast } from 'sonner';
+import React from 'react';
 import { X, Trash } from 'lucide-react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 
@@ -17,13 +17,13 @@ interface ConfirmRemoveCategoryDrawerProps {
 export function ConfirmRemoveCategoryDrawer({ category, open, onOpenChange }: ConfirmRemoveCategoryDrawerProps) {
   const { removeCategory } = useCategories();
 
-  const handleRemoveCategory = () => {
-    if (!category) {
-      toast('Categoria não encontrada');
-      return;
-    }
+  const [isRemoving, setIsRemoving] = React.useState(false);
 
-    removeCategory(category._id);
+  const handleRemoveCategory = async () => {
+    if (isRemoving || !category) return;
+    setIsRemoving(true);
+    await removeCategory(category._id);
+    setIsRemoving(false);
     onOpenChange(false);
   };
 
@@ -67,18 +67,20 @@ export function ConfirmRemoveCategoryDrawer({ category, open, onOpenChange }: Co
             </div>
 
             <div className="rounded-xl border border-border bg-[#f5f5f5] p-3 dark:border-[#242424] dark:bg-[#1a1a1a]">
-              <p className="text-sm font-medium text-foreground">
+              <p id="remove-warning" className="text-sm font-medium text-foreground">
                 Esta ação não pode ser desfeita.
               </p>
             </div>
 
             <button
               type="button"
+              disabled={isRemoving}
+              aria-describedby="remove-warning"
               onClick={handleRemoveCategory}
-              className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-error)] text-sm font-semibold text-white"
+              className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-[var(--color-error)] text-sm font-semibold text-white disabled:opacity-60"
             >
               <Trash className="h-5 w-5" />
-              Remover {category.name}
+              {isRemoving ? 'Removendo…' : `Remover ${category.name}`}
             </button>
           </div>
         </DrawerPrimitive.Content>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 
 import { PagesEnum } from '@/types/enums';
@@ -13,28 +15,43 @@ import { NewCategoryDrawer } from './new-category-drawer';
 export function Footer() {
   const pathname = usePathname();
   const { products, allProductsWithoutPrice, allProductsInCartWithoutPrice } = useProducts();
+  const [categoryDrawerOpen, setCategoryDrawerOpen] = useState(false);
 
   const isHomePage = pathname === PagesEnum.home;
   const shouldRenderPrice = !!products && !isHomePage && (!allProductsWithoutPrice || !allProductsInCartWithoutPrice);
 
   return (
     <footer className={'fixed bottom-0 w-full m-auto rounded-t-sm max-w-3xl bg-white dark:bg-background'}>
-      {shouldRenderPrice && (<div className="p-4 flex justify-between gap-4 mx-auto">
-        {!allProductsWithoutPrice && (
-          <p className="font-semibold">Total: {convertToCurrency(calculateTotalValue(products).totalProductsValue)}</p>
-        )}
+      {shouldRenderPrice && (
+        <div className="p-4 flex justify-between gap-4 mx-auto">
+          {!allProductsWithoutPrice && (
+            <p className="font-semibold">Total: {convertToCurrency(calculateTotalValue(products).totalProductsValue)}</p>
+          )}
 
-        {!allProductsInCartWithoutPrice && (
-          <p className="font-semibold text-teal-400">Carrinho: {convertToCurrency(calculateTotalValue(products).filteredProductsValue)}</p>
-        )}
-      </div>)
-      }
+          {!allProductsInCartWithoutPrice && (
+            <p className="font-semibold text-teal-400">Carrinho: {convertToCurrency(calculateTotalValue(products).filteredProductsValue)}</p>
+          )}
+        </div>
+      )}
 
       <div className={isHomePage ? 'w-full p-4' : 'flex items-center gap-2'}>
         {!isHomePage ? (
           <NewProductForm />
         ) : (
-          <NewCategoryDrawer />
+          <>
+            <button
+              onClick={() => setCategoryDrawerOpen(true)}
+              className="flex h-12 w-full items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)] transition-opacity hover:opacity-90 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)]"
+              aria-label="Adicionar categoria"
+            >
+              <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
+              <span className="text-sm font-semibold text-[var(--color-on-primary)]">
+                Adicionar categoria
+              </span>
+            </button>
+
+            <NewCategoryDrawer open={categoryDrawerOpen} onOpenChange={setCategoryDrawerOpen} />
+          </>
         )}
       </div>
     </footer>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -40,9 +40,9 @@ export function Footer() {
         ) : (
           <>
             <button
+              type="button"
               onClick={() => setCategoryDrawerOpen(true)}
               className="flex h-12 w-full items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)] transition-opacity hover:opacity-90 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)]"
-              aria-label="Adicionar categoria"
             >
               <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
               <span className="text-sm font-semibold text-[var(--color-on-primary)]">

--- a/src/components/new-category-drawer.tsx
+++ b/src/components/new-category-drawer.tsx
@@ -1,27 +1,21 @@
 'use client';
 
-import React from 'react';
-import { Plus } from 'lucide-react';
+import { X, Plus } from 'lucide-react';
+import { Drawer as DrawerPrimitive } from 'vaul';
 import { useForm, FormProvider } from 'react-hook-form';
 
+import { cn } from '@/lib/utils';
 import { useCategories } from '@/context';
 import { Input } from '@/components/ui/input';
 import { CategoryProps } from '@/types/interfaces';
-import {
-  Drawer,
-  DrawerTitle,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerContent,
-  DrawerTrigger,
-  DrawerDescription
-} from '@/components/ui/drawer';
 
-import { ActionButton } from './action-button';
+interface NewCategoryDrawerProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
 
-export function NewCategoryDrawer() {
+export function NewCategoryDrawer({ open, onOpenChange }: NewCategoryDrawerProps) {
   const { addCategory } = useCategories();
-  const [open, setOpen] = React.useState<boolean>(false);
 
   const methods = useForm<CategoryProps>({
     defaultValues: {
@@ -31,57 +25,81 @@ export function NewCategoryDrawer() {
 
   const onSubmit = methods.handleSubmit((data) => {
     addCategory(data);
-
     methods.reset();
-    setOpen?.(false);
+    onOpenChange?.(false);
   });
 
   return (
-    <Drawer open={open} onOpenChange={setOpen}>
-      <DrawerTrigger asChild>
-        <button
-          className="flex h-12 w-full items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)] transition-opacity hover:opacity-90 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)]"
-          aria-label="Adicionar categoria"
+    <DrawerPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DrawerPrimitive.Portal>
+        <DrawerPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60" />
+
+        <DrawerPrimitive.Content
+          className={cn(
+            'fixed inset-x-0 bottom-0 z-50 flex flex-col',
+            'rounded-t-2xl bg-background outline-none',
+            'shadow-[0_-4px_12px_rgba(0,0,0,0.08)]'
+          )}
         >
-          <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
-          <span className="text-sm font-semibold text-[var(--color-on-primary)]">
-            Adicionar categoria
-          </span>
-        </button>
-      </DrawerTrigger>
+          <div className="flex flex-shrink-0 justify-center pt-2.5">
+            <div className="h-[5px] w-11 rounded-full bg-[#d1d5db]" />
+          </div>
 
-      <DrawerContent className='max-w-3xl my-0 mx-auto'>
-        <div className="mx-auto w-full max-w-lg">
+          <div className="flex flex-col gap-4 px-5 pb-4 pt-4">
+            <div className="flex items-start justify-between">
+              <div className="flex flex-1 flex-col gap-1 pr-3">
+                <DrawerPrimitive.Title className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-foreground">
+                  Nova categoria
+                </DrawerPrimitive.Title>
+                <DrawerPrimitive.Description className="text-sm leading-[1.5] text-[#374151] dark:text-[#a1a1aa]">
+                  Digite o nome e a categoria fica disponível imediatamente.
+                </DrawerPrimitive.Description>
+              </div>
 
-          <DrawerHeader>
-            <DrawerTitle>Adicionar categoria</DrawerTitle>
+              <button
+                type="button"
+                aria-label="Fechar"
+                onClick={() => onOpenChange?.(false)}
+                className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-white dark:border-[#242424] dark:bg-[#101010]"
+              >
+                <X className="h-5 w-5 text-foreground" />
+              </button>
+            </div>
 
-            <DrawerDescription>
-            Digite o nome da categoria no campo abaixo para criar uma nova categoria.
-            </DrawerDescription>
-          </DrawerHeader>
-
-          <DrawerFooter>
             <FormProvider {...methods}>
-              <form onSubmit={onSubmit} className="space-y-4">
-                <div className='px-4 space-y-4'>
+              <form onSubmit={onSubmit} className="flex flex-col gap-4">
+                <div className="flex flex-col gap-[7px]">
+                  <span className="text-[13px] font-bold leading-[1.35] text-foreground">
+                    Categoria
+                  </span>
                   <Input
                     required
                     id="name"
                     type="text"
                     placeholder="Nome da categoria"
+                    className="h-10 rounded-lg px-3.5 text-base font-semibold"
                     {...methods.register('name')}
                   />
                 </div>
 
-                <DrawerFooter className="mt-4">
-                  <ActionButton type="submit" icon={Plus}/>
-                </DrawerFooter>
+                <div className="flex flex-col gap-2.5">
+                  <button
+                    type="submit"
+                    className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-foreground text-sm font-semibold text-background"
+                  >
+                    <Plus className="h-5 w-5" />
+                    Criar categoria
+                  </button>
+
+                  <p className="text-[13px] font-medium leading-[1.4] text-[#898989]">
+                    Enter também cria quando o nome estiver preenchido.
+                  </p>
+                </div>
               </form>
             </FormProvider>
-          </DrawerFooter>
-        </div>
-      </DrawerContent>
-    </Drawer>
+          </div>
+        </DrawerPrimitive.Content>
+      </DrawerPrimitive.Portal>
+    </DrawerPrimitive.Root>
   );
 }

--- a/src/components/new-category-drawer.tsx
+++ b/src/components/new-category-drawer.tsx
@@ -24,13 +24,19 @@ export function NewCategoryDrawer({ open, onOpenChange }: NewCategoryDrawerProps
   });
 
   const onSubmit = methods.handleSubmit((data) => {
-    addCategory(data);
+    addCategory({ name: data.name } as CategoryProps);
     methods.reset();
     onOpenChange?.(false);
   });
 
   return (
-    <DrawerPrimitive.Root open={open} onOpenChange={onOpenChange}>
+    <DrawerPrimitive.Root
+      open={open}
+      onOpenChange={(value) => {
+        if (!value) methods.reset();
+        onOpenChange?.(value);
+      }}
+    >
       <DrawerPrimitive.Portal>
         <DrawerPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60" />
 


### PR DESCRIPTION
## Summary

- Redesign `NewCategoryDrawer`: migra do wrapper `DrawerContent` para `DrawerPrimitive` (Vaul), extrai trigger para `footer.tsx`, aplica linguagem visual do `ProductManagerSheet` (Cal Sans 28px, drag handle, botão X circular)
- Redesign `ConfirmRemoveCategoryDrawer`: mesma migração visual, mantém interface de props intacta, adiciona card de aviso "Esta ação não pode ser desfeita." e botão destrutivo com guard contra duplo-submit (`isRemoving` state)
- `footer.tsx`: gerencia `categoryDrawerOpen` state externamente e renderiza o trigger "Adicionar categoria"

## Test Plan

- [ ] Botão "Adicionar categoria" na home abre o bottom sheet com drag handle e título "Nova categoria" em Cal Sans
- [ ] Drag to dismiss reseta o campo de nome
- [ ] Criar categoria com Enter funciona
- [ ] Botão X fecha o drawer e reseta o campo
- [ ] `ConfirmRemoveCategoryDrawer` abre com o nome da categoria no título (Cal Sans)
- [ ] Card "Esta ação não pode ser desfeita." visível
- [ ] Botão de remover desabilita durante o request (`disabled:opacity-60`)
- [ ] Dark mode correto em ambos os drawers
- [ ] `npx tsc --noEmit` passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)