### PR TITLE
fix: treat zero as valid currency value and return '-' for invalid input

### DIFF
--- a/src/utils/convertToCurrency/index.ts
+++ b/src/utils/convertToCurrency/index.ts
@@ -3,8 +3,8 @@ export const convertToCurrency = (value: number | string) => {
 
   const convertedValue = Number(parsedValue);
 
-  if (!convertedValue || isNaN(convertedValue)) {
-    return 'Valor inválido';
+  if (isNaN(convertedValue)) {
+    return '-';
   }
 
   return new Intl.NumberFormat('pt-BR', {


### PR DESCRIPTION
## Summary

- Substitui a condição `!convertedValue || isNaN(...)` por `isNaN(...)` em `convertToCurrency`
- Valor `0` agora formata corretamente como `R$ 0,00` em vez de cair no branch de erro
- Troca o retorno `'Valor inválido'` por `'-'`, placeholder neutro adequado para produtos sem preço cadastrado

## Test plan

- [ ] Produto com preço `0` exibe `R$ 0,00`
- [ ] Produto sem preço (null/undefined/string vazia) exibe `-`
- [ ] Produto com preço numérico válido formata normalmente em BRL

🤖 Generated with [Claude Code](https://claude.com/claude-code)