### PR TITLE
fix: adapt product modal height when virtual keyboard opens on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,6 +113,8 @@
 [data-vaul-drawer] {
   touch-action: none;
   will-change: transform;
+  max-height: 90vh; /* fallback para navegadores sem suporte a dvh */
+  max-height: 90dvh; /* viewport dinâmico — reduz automaticamente quando o teclado abre */
 }
 
 [data-vaul-drawer][data-vaul-drawer-visible='true'] {

--- a/src/components/product-manager-sheet.tsx
+++ b/src/components/product-manager-sheet.tsx
@@ -127,14 +127,15 @@ export const ProductManagerSheet = ({
           className={cn(
             'fixed inset-x-0 bottom-0 z-50 flex flex-col',
             'rounded-t-2xl bg-background outline-none',
-            'shadow-[0_-4px_12px_rgba(0,0,0,0.08)]'
+            'shadow-[0_-4px_12px_rgba(0,0,0,0.08)]',
+            'max-h-[90dvh]'
           )}
         >
           <div className="flex flex-shrink-0 justify-center pt-2.5">
             <div className="h-[5px] w-11 rounded-full bg-[#d1d5db]" />
           </div>
 
-          <div className="flex flex-col gap-4 overflow-y-auto px-5 pb-4 pt-4">
+          <div className="min-h-0 flex flex-col gap-4 overflow-y-auto px-5 pb-4 pt-4">
             <div className="flex items-start justify-between">
               <div className="flex flex-1 flex-col gap-1 pr-3">
                 <DrawerPrimitive.Title className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-foreground">


### PR DESCRIPTION
## Problema

Ao focar em qualquer campo do modal de criação/edição de produto em dispositivos móveis, o teclado virtual causava:

- Área em branco excessiva entre o conteúdo do modal e o teclado
- Campos e ações (botão de salvar) ficando inacessíveis
- Conteúdo não reajustando corretamente à área visível

## Causa raiz

O `DrawerPrimitive.Content` não tinha `max-height` definido. Sem essa restrição, o drawer crescia para acomodar todo o conteúdo e ignorava a redução do viewport causada pelo teclado virtual. O `overflow-y-auto` no div interno nunca ativava o scroll porque, sem um pai com altura limitada, um filho `flex` não reduz abaixo do tamanho do seu conteúdo (precisa de `min-h-0` para isso).

## Solução

- **`max-h-[90dvh]`** no `DrawerPrimitive.Content`: a unidade `dvh` (Dynamic Viewport Height) se ajusta automaticamente quando o teclado abre/fecha, contraindo o drawer para caber na área útil visível.
- **`min-h-0`** no div scrollável interno: permite que o flex child realmente encolha e ative o scroll dentro do container restrito.
- **Fallback `90vh`** no `globals.css` via dupla declaração CSS: navegadores sem suporte a `dvh` usam `90vh`; navegadores modernos aplicam `90dvh`.

## Arquivos alterados

- `src/components/product-manager-sheet.tsx` — `max-h-[90dvh]` no Content + `min-h-0` no div scrollável
- `src/app/globals.css` — fallback `max-height: 90vh` / `90dvh` no seletor `[data-vaul-drawer]`

## Como a solução lida com o teclado virtual

`dvh` é suportado desde Safari 15.4 (março 2022), Chrome 108 (dez 2022) e Firefox 101 (maio 2022) — cobrindo virtualmente toda a base de usuários móveis modernos. Quando o teclado abre, o browser reduz o viewport dinâmico e o drawer se adapta automaticamente, mantendo o conteúdo visível e scrollável sem JavaScript ou listeners de evento.

## Lint

```
✔ No ESLint warnings or errors
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)