### PR TITLE
fix: make scrollable div fill drawer height to eliminate white space …

### DIFF
--- a/src/components/product-manager-sheet.tsx
+++ b/src/components/product-manager-sheet.tsx
@@ -135,7 +135,7 @@ export const ProductManagerSheet = ({
             <div className="h-[5px] w-11 rounded-full bg-[#d1d5db]" />
           </div>
 
-          <div className="min-h-0 flex flex-col gap-4 overflow-y-auto px-5 pb-4 pt-4">
+          <div className="min-h-0 flex-1 flex flex-col gap-4 overflow-y-auto px-5 pb-4 pt-4">
             <div className="flex items-start justify-between">
               <div className="flex flex-1 flex-col gap-1 pr-3">
                 <DrawerPrimitive.Title className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-foreground">


### PR DESCRIPTION
…on keyboard open

Add flex-1 to the inner scrollable div so it always fills the available drawer height. Vaul's onVisualViewportChange already adjusts style.height on the drawer when the keyboard opens, but without flex-1 the inner div stayed at its natural content height — shorter than the vaul-set height — leaving a white gap at the bottom. With flex-1 + min-h-0 the div always fills (expanding without whitespace, or shrinking and scrolling).