### PR TITLE
fix: product modal state bugs after app loses focus on mobile

### DIFF
--- a/docs/superpowers/plans/2026-06-07-product-modal-mobile-focus-loss-bug.md
+++ b/docs/superpowers/plans/2026-06-07-product-modal-mobile-focus-loss-bug.md
@@ -1,0 +1,459 @@
+# Product Modal Mobile Focus-Loss Bug Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Corrigir cinco bugs de gerenciamento de estado que causam erro falso na criação e campos vazios na edição de produtos após o app ser enviado ao background no mobile.
+
+**Architecture:** Três grupos de mudanças em arquivos distintos. ProductContext recebe re-throw de erro e functional updates para eliminar closures estáticas. CategoryContext recebe o mesmo padrão de functional updates. ProductManagerSheet recebe onSubmit async (depende do re-throw), correção de deps do useEffect e tratamento de falha no fetch de edição. Não há setup de testes automatizados no projeto — verificação é manual via DevTools.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, React Hook Form 7, Vaul 1 (drawer), Sonner 1 (toast)
+
+---
+
+### Task 1: ProductContext — re-throw + functional updates
+
+**Files:**
+- Modify: `src/context/ProductContext.tsx`
+
+- [ ] **Step 1: Adicionar `throw err` no catch de `managerProduct`**
+
+Localizar o catch block de `managerProduct` (linha ~172). Substituir:
+
+```typescript
+  } catch (err) {
+    setError(err instanceof Error ? err.message : 'An error occurred');
+  } finally {
+```
+
+Por:
+
+```typescript
+  } catch (err) {
+    setError(err instanceof Error ? err.message : 'An error occurred');
+    throw err;
+  } finally {
+```
+
+- [ ] **Step 2: Functional update — edit path, categoria mudou**
+
+Localizar o bloco `setCategories` dentro do `if (oldCategory && oldCategory._id !== updatedProduct.category._id)` (~linha 119). Substituir:
+
+```typescript
+          setCategories(categories.map(category => {
+
+            if (category._id === oldCategory._id) {
+              return {
+                ...category,
+                products: (category.products || []).filter(p => p._id !== updatedProduct._id)
+              };
+            }
+
+            if (category._id === updatedProduct.category._id) {
+              return {
+                ...category,
+                products: [...(category.products || []), updatedProduct]
+              };
+            }
+
+            return category;
+          }));
+```
+
+Por:
+
+```typescript
+          setCategories(prev => prev.map(category => {
+
+            if (category._id === oldCategory._id) {
+              return {
+                ...category,
+                products: (category.products || []).filter(p => p._id !== updatedProduct._id)
+              };
+            }
+
+            if (category._id === updatedProduct.category._id) {
+              return {
+                ...category,
+                products: [...(category.products || []), updatedProduct]
+              };
+            }
+
+            return category;
+          }));
+```
+
+- [ ] **Step 3: Functional update — edit path, mesma categoria**
+
+Localizar o `else` do bloco acima (~linha 138). Substituir:
+
+```typescript
+          setCategories(categories.map(category => ({
+            ...category,
+            products: category?.products?.map(product =>
+              product?._id === updatedProduct?._id ? updatedProduct : product
+            )
+          })));
+```
+
+Por:
+
+```typescript
+          setCategories(prev => prev.map(category => ({
+            ...category,
+            products: category?.products?.map(product =>
+              product?._id === updatedProduct?._id ? updatedProduct : product
+            )
+          })));
+```
+
+- [ ] **Step 4: Functional update — create path**
+
+Localizar o `setCategories` dentro do `else` (create, ~linha 163). Substituir:
+
+```typescript
+        setCategories(categories.map(category => ({
+          ...category,
+          products: category?._id === newProduct.category?._id ? [...category.products || [], newProduct] : category.products
+        })));
+```
+
+Por:
+
+```typescript
+        setCategories(prev => prev.map(category => ({
+          ...category,
+          products: category?._id === newProduct.category?._id ? [...category.products || [], newProduct] : category.products
+        })));
+```
+
+- [ ] **Step 5: Functional update — `removeProduct`**
+
+Localizar o `setCategories` dentro de `removeProduct` (~linha 197). Substituir:
+
+```typescript
+      setCategories(categories.map(category => ({
+        ...category,
+        products: category.products?.filter(product => product._id !== id)
+      })));
+```
+
+Por:
+
+```typescript
+      setCategories(prev => prev.map(category => ({
+        ...category,
+        products: category.products?.filter(product => product._id !== id)
+      })));
+```
+
+- [ ] **Step 6: Functional update — `removeAllProducts`**
+
+Localizar o `setCategories` dentro de `removeAllProducts` (~linha 217). Substituir:
+
+```typescript
+      setCategories(categories.map(category => ({
+        ...category,
+        products: []
+      })));
+```
+
+Por:
+
+```typescript
+      setCategories(prev => prev.map(category => ({
+        ...category,
+        products: []
+      })));
+```
+
+- [ ] **Step 7: Functional update — `toggleCart`**
+
+Localizar o `setCategories` dentro de `toggleCart` (~linha 251). Substituir:
+
+```typescript
+      setCategories(categories.map(category => ({
+        ...category,
+        products: category.products?.map(product => product._id === id ? updatedProduct : product)
+      })));
+```
+
+Por:
+
+```typescript
+      setCategories(prev => prev.map(category => ({
+        ...category,
+        products: category.products?.map(product => product._id === id ? updatedProduct : product)
+      })));
+```
+
+- [ ] **Step 8: Rodar lint**
+
+```bash
+npm run lint
+```
+
+Resultado esperado: sem erros ou warnings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/context/ProductContext.tsx
+git commit -m "fix: re-throw error in managerProduct and use functional updates in ProductContext"
+```
+
+---
+
+### Task 2: CategoryContext — functional updates
+
+**Files:**
+- Modify: `src/context/CategoryContext.tsx`
+
+- [ ] **Step 1: Functional update — `addCategory`**
+
+Localizar a função `addCategory` (~linha 38). Substituir as três últimas linhas do corpo da função (de `const updatedCategories` até o `toast`):
+
+```typescript
+    const updatedCategories = [...categories, data].sort((categoryA, categoryB) =>
+      categoryA.name.localeCompare(categoryB.name, 'pt-BR', { sensitivity: 'base' })
+    );
+
+    setCategories(updatedCategories);
+    toast('Categoria criada com sucesso');
+```
+
+Por:
+
+```typescript
+    setCategories(prev =>
+      [...prev, data].sort((categoryA, categoryB) =>
+        categoryA.name.localeCompare(categoryB.name, 'pt-BR', { sensitivity: 'base' })
+      )
+    );
+    toast('Categoria criada com sucesso');
+```
+
+- [ ] **Step 2: Functional update — `removeCategory`**
+
+Localizar o `setCategories` dentro de `removeCategory` (~linha 73). Substituir:
+
+```typescript
+      setCategories(categories.filter(category => category._id !== id));
+```
+
+Por:
+
+```typescript
+      setCategories(prev => prev.filter(category => category._id !== id));
+```
+
+- [ ] **Step 3: Rodar lint**
+
+```bash
+npm run lint
+```
+
+Resultado esperado: sem erros ou warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/context/CategoryContext.tsx
+git commit -m "fix: functional updates in CategoryContext to avoid stale closure"
+```
+
+---
+
+### Task 3: ProductManagerSheet — onSubmit async
+
+**Files:**
+- Modify: `src/components/product-manager-sheet.tsx:54-58`
+
+Esta task depende da Task 1 (Step 1): sem o `throw err` em `managerProduct`, o `catch` aqui nunca seria executado e o modal fecharia mesmo em caso de erro.
+
+- [ ] **Step 1: Tornar `onSubmit` async e fechar modal somente no sucesso**
+
+Localizar `onSubmit` (~linha 54). Substituir:
+
+```typescript
+  const onSubmit = methods.handleSubmit((data) => {
+    managerProduct({ product: { ...data, categoryId: data.categoryId } });
+    methods.reset();
+    onOpenChange?.(false);
+  });
+```
+
+Por:
+
+```typescript
+  const onSubmit = methods.handleSubmit(async (data) => {
+    try {
+      await managerProduct({ product: { ...data, categoryId: data.categoryId } });
+      methods.reset();
+      onOpenChange?.(false);
+    } catch {
+      // erro já tratado em managerProduct via toast e setError
+    }
+  });
+```
+
+- [ ] **Step 2: Rodar lint**
+
+```bash
+npm run lint
+```
+
+Resultado esperado: sem erros ou warnings.
+
+---
+
+### Task 4: ProductManagerSheet — corrigir deps do useEffect
+
+**Files:**
+- Modify: `src/components/product-manager-sheet.tsx:113`
+
+- [ ] **Step 1: Remover `categories.length` e `methods` do array de deps**
+
+Localizar o fechamento do `useEffect` (linha 113). Substituir:
+
+```typescript
+  }, [open, product?._id, isEdit, categories.length, selectedCategoryId, methods]);
+```
+
+Por:
+
+```typescript
+  }, [open, product?._id, isEdit, selectedCategoryId]);
+```
+
+A guarda `categories.length > 0` no corpo do effect (~linha 98) permanece intocada — ela ainda previne o reset do form antes das categorias carregarem.
+
+- [ ] **Step 2: Rodar lint**
+
+```bash
+npm run lint
+```
+
+Resultado esperado: sem erros ou warnings.
+
+---
+
+### Task 5: ProductManagerSheet — tratar falha no fetch de edição
+
+**Files:**
+- Modify: `src/components/product-manager-sheet.tsx:1-18` (imports)
+- Modify: `src/components/product-manager-sheet.tsx:87-93`
+
+- [ ] **Step 1: Adicionar import de `toast`**
+
+No topo do arquivo, adicionar após a linha `'use client';`:
+
+```typescript
+import { toast } from 'sonner';
+```
+
+O bloco de imports completo ficará:
+
+```typescript
+'use client';
+
+import * as React from 'react';
+import { toast } from 'sonner';
+import { X, Plus, Check } from 'lucide-react';
+import { Drawer as DrawerPrimitive } from 'vaul';
+import { useForm, FormProvider } from 'react-hook-form';
+```
+
+- [ ] **Step 2: Substituir `console.error` por toast + fechar modal**
+
+Localizar o catch block dentro de `doFetch` (~linha 87). Substituir:
+
+```typescript
+        } catch (error) {
+          if ((error as { name?: string }).name !== 'AbortError') {
+            console.error('Error fetching product:', error);
+          }
+        }
+```
+
+Por:
+
+```typescript
+        } catch (error) {
+          if ((error as { name?: string }).name !== 'AbortError') {
+            toast.error('Não foi possível carregar o produto. Tente novamente.');
+            onOpenChange?.(false);
+          }
+        }
+```
+
+- [ ] **Step 3: Rodar lint**
+
+```bash
+npm run lint
+```
+
+Resultado esperado: sem erros ou warnings.
+
+- [ ] **Step 4: Commit (Tasks 3, 4 e 5 juntas)**
+
+```bash
+git add src/components/product-manager-sheet.tsx
+git commit -m "fix: async onSubmit, remove stale useEffect deps, toast on edit fetch failure"
+```
+
+---
+
+### Task 6: Verificação manual
+
+- [ ] **Step 1: Iniciar dev server**
+
+```bash
+npm run dev
+```
+
+Acessar `http://localhost:3000`.
+
+- [ ] **Step 2: Criação — fluxo normal**
+
+1. Navegar para uma categoria
+2. Clicar em "Novo produto", preencher o nome
+3. Clicar "Adicionar produto"
+4. **Esperado:** Modal fecha, produto aparece na lista, toast de sucesso
+
+- [ ] **Step 3: Criação — falha de rede**
+
+1. DevTools → Network → marcar "Offline"
+2. Abrir modal de novo produto, preencher nome
+3. Clicar "Adicionar produto"
+4. **Esperado:** Modal permanece aberto, toast de erro aparece, nome continua no campo
+5. Desmarcar "Offline"
+6. Clicar "Adicionar produto" novamente
+7. **Esperado:** Produto criado, modal fecha, toast de sucesso
+
+- [ ] **Step 4: Edição — fluxo normal**
+
+1. Navegar para categoria com produtos
+2. Clicar no ícone de edição de um produto
+3. **Esperado:** Modal abre com nome e demais campos preenchidos
+4. Alterar o nome, clicar "Salvar alterações"
+5. **Esperado:** Modal fecha, produto atualizado na lista
+
+- [ ] **Step 5: Edição — fetch falha**
+
+1. DevTools → Network → bloquear URL `api/products` (botão direito na requisição → "Block request URL")
+2. Clicar no ícone de edição de um produto
+3. **Esperado:** Modal fecha automaticamente, toast "Não foi possível carregar o produto. Tente novamente."
+4. Remover o bloqueio
+5. Clicar em editar novamente
+6. **Esperado:** Modal abre com dados corretos
+
+- [ ] **Step 6: Simular background**
+
+1. Abrir modal de novo produto, preencher o nome
+2. Trocar para outra aba por 5-10 segundos e voltar
+3. Clicar "Adicionar produto"
+4. **Esperado:** Produto criado, modal fecha, sem toast de erro falso
+
+- [ ] **Step 7: Verificar console**
+
+Abrir DevTools → Console. Confirmar que não há erros do tipo `console.error('Error fetching product')` durante o fluxo de edição.

--- a/docs/superpowers/specs/2026-06-07-product-modal-mobile-focus-loss-bug-design.md
+++ b/docs/superpowers/specs/2026-06-07-product-modal-mobile-focus-loss-bug-design.md
@@ -1,0 +1,191 @@
+# Design: Correção de bugs no modal de produto após perda de foco no mobile
+
+**Data:** 2026-06-07  
+**Branch:** fix+modal-mobile-keyboard-layout  
+**Escopo:** Dois bugs no fluxo de criação e edição de produto que se manifestam após o app ser enviado ao background
+
+---
+
+## Problema
+
+Após o app perder foco (tela bloqueada, troca de aplicativo, aba em background), os fluxos de criação e edição de produto apresentam comportamento incorreto ao retornar:
+
+- **Criação:** Toast de erro é exibido, mas o produto é criado no servidor
+- **Edição:** O modal abre com campos vazios
+
+O app é acessado via browser (não PWA instalado), portanto o estado React persiste durante o background. Os bugs são causados por falhas no código, não por lifecycle do browser.
+
+---
+
+## Diagnóstico
+
+### Bug 1 — `onSubmit` não aguarda `managerProduct`
+
+**Localização:** `src/components/product-manager-sheet.tsx:54-58`
+
+```typescript
+// Antes (bugado)
+const onSubmit = methods.handleSubmit((data) => {
+  managerProduct({ product: { ...data, categoryId: data.categoryId } });
+  methods.reset();           // executa antes do fetch completar
+  onOpenChange?.(false);     // fecha modal antes de saber o resultado
+});
+```
+
+O modal fecha e o form é resetado imediatamente, antes da requisição terminar. Se a requisição falha (rede instável ao voltar do background), o toast de erro aparece com o modal já fechado. Se o servidor processou a requisição antes de retornar erro de rede/resposta, o produto existe mas o usuário viu erro.
+
+### Bug 2 — `managerProduct` não relança o erro
+
+**Localização:** `src/context/ProductContext.tsx:172-174`
+
+```typescript
+// Antes
+} catch (err) {
+  setError(err instanceof Error ? err.message : 'An error occurred');
+  // sem throw — caller não consegue saber se houve erro
+}
+```
+
+Sem o `throw err`, o `await managerProduct()` no `onSubmit` nunca lança exceção. O `try/catch` do caller nunca entra no `catch`, e o modal fecha mesmo quando houve falha.
+
+### Bug 3 — Stale closure em `setCategories`
+
+**Localização:** `src/context/ProductContext.tsx` — todas as operações que chamam `setCategories`
+
+```typescript
+// Antes
+setCategories(categories.map(category => ({ ... })));
+//            ↑ capturado no render anterior — pode estar obsoleto
+```
+
+Se entre o submit e a resposta da API o estado `categories` for atualizado por outra operação, o `setCategories` sobrescreve o estado atual com dados obsoletos.
+
+### Bug 4 — `categories.length` e `methods` como deps do `useEffect`
+
+**Localização:** `src/components/product-manager-sheet.tsx:113`
+
+```typescript
+}, [open, product?._id, isEdit, categories.length, selectedCategoryId, methods]);
+```
+
+- `categories.length`: ao adicionar/remover qualquer categoria com o modal aberto, o effect re-executa, abortando o fetch do produto em edição e reiniciando o form em criação
+- `methods`: referência estável do React Hook Form, não precisa estar nas deps
+
+### Bug 5 — Falha no fetch de edição sem feedback
+
+**Localização:** `src/components/product-manager-sheet.tsx:87-93`
+
+```typescript
+// Antes
+} catch (error) {
+  if ((error as { name?: string }).name !== 'AbortError') {
+    console.error('Error fetching product:', error);
+    // modal permanece aberto com campos vazios
+  }
+}
+```
+
+Quando o fetch do produto falha, o modal abre com campos vazios e nenhum feedback ao usuário.
+
+---
+
+## Solução (Opção A — Correções cirúrgicas)
+
+Cinco mudanças cirúrgicas em dois arquivos.
+
+### Fix 1 — `onSubmit` async com fechamento condicional
+
+**Arquivo:** `src/components/product-manager-sheet.tsx`
+
+```typescript
+const onSubmit = methods.handleSubmit(async (data) => {
+  try {
+    await managerProduct({ product: { ...data, categoryId: data.categoryId } });
+    methods.reset();
+    onOpenChange?.(false);
+  } catch {
+    // erro já tratado no managerProduct (toast + setError)
+  }
+});
+```
+
+O modal só fecha se a operação tiver sucesso. Se falhar, permanece aberto com os dados preenchidos.
+
+### Fix 2 — `managerProduct` relança o erro
+
+**Arquivo:** `src/context/ProductContext.tsx`
+
+```typescript
+} catch (err) {
+  setError(err instanceof Error ? err.message : 'An error occurred');
+  throw err;  // ← permite ao caller reagir à falha
+}
+```
+
+### Fix 3 — Functional updates em `setCategories`
+
+**Arquivo:** `src/context/ProductContext.tsx` — todas as operações: create, edit (duas branches), delete, toggleCart; e `addCategory` em `CategoryContext.tsx`
+
+```typescript
+// Padrão antes
+setCategories(categories.map(category => ({ ... })));
+
+// Padrão depois
+setCategories(prev => prev.map(category => ({ ... })));
+```
+
+O callback `prev =>` recebe sempre o estado atual do React no momento da execução.
+
+### Fix 4 — Corrigir deps do `useEffect`
+
+**Arquivo:** `src/components/product-manager-sheet.tsx`
+
+```typescript
+// Antes
+}, [open, product?._id, isEdit, categories.length, selectedCategoryId, methods]);
+
+// Depois
+}, [open, product?._id, isEdit, selectedCategoryId]);
+```
+
+A guarda `categories.length > 0` dentro do effect pode permanecer — ela previne reset do form antes das categorias carregarem, mas não precisa ser dep do effect.
+
+### Fix 5 — Toast + fechar modal se fetch de edição falhar
+
+**Arquivo:** `src/components/product-manager-sheet.tsx`
+
+```typescript
+} catch (error) {
+  if ((error as { name?: string }).name !== 'AbortError') {
+    toast.error('Não foi possível carregar o produto. Tente novamente.');
+    onOpenChange?.(false);
+  }
+}
+```
+
+---
+
+## Arquivos modificados
+
+| Arquivo | Fixes |
+|---------|-------|
+| `src/components/product-manager-sheet.tsx` | Fix 1, Fix 4, Fix 5 |
+| `src/context/ProductContext.tsx` | Fix 2, Fix 3 (managerProduct, removeProduct, removeAllProducts, toggleCart) |
+| `src/context/CategoryContext.tsx` | Fix 3 (addCategory, removeCategory) |
+
+---
+
+## Comportamento esperado após a correção
+
+- **Criação:** Modal permanece aberto se a requisição falhar; fecha normalmente no sucesso
+- **Criação (rede instável):** Toast de erro aparece com modal ainda aberto; usuário pode tentar novamente
+- **Edição:** Se o fetch do produto falhar, modal fecha com toast de erro (não fica aberto com campos vazios)
+- **Estado:** Nenhuma operação sobrescreve o estado de categorias com dados obsoletos
+
+---
+
+## Fora do escopo
+
+- Revalidação de sessão NextAuth no foco (`refetchOnWindowFocus`) — pode ser endereçada se o bug persistir após estas correções
+- Listener de `visibilitychange` para refresh proativo de categorias
+- Loop de re-render potencial no `useEffect` do `CategoryContext` (`filterCategory` → `filteredCategory` → re-run)

--- a/src/components/product-manager-sheet.tsx
+++ b/src/components/product-manager-sheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { toast } from 'sonner';
 import { X, Plus, Check } from 'lucide-react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 import { useForm, FormProvider } from 'react-hook-form';
@@ -51,10 +52,14 @@ export const ProductManagerSheet = ({
     },
   });
 
-  const onSubmit = methods.handleSubmit((data) => {
-    managerProduct({ product: { ...data, categoryId: data.categoryId } });
-    methods.reset();
-    onOpenChange?.(false);
+  const onSubmit = methods.handleSubmit(async (data) => {
+    try {
+      await managerProduct({ product: { ...data, categoryId: data.categoryId } });
+      methods.reset();
+      onOpenChange?.(false);
+    } catch {
+      // erro já tratado em managerProduct via toast e setError
+    }
   });
 
   const [isLoadingProduct, setIsLoadingProduct] = React.useState(false);
@@ -86,7 +91,8 @@ export const ProductManagerSheet = ({
           });
         } catch (error) {
           if ((error as { name?: string }).name !== 'AbortError') {
-            console.error('Error fetching product:', error);
+            toast.error('Não foi possível carregar o produto. Tente novamente.');
+            onOpenChange?.(false);
           }
         } finally {
           setIsLoadingProduct(false);
@@ -110,7 +116,11 @@ export const ProductManagerSheet = ({
     }
 
     return () => controller.abort();
-  }, [open, product?._id, isEdit, categories.length, selectedCategoryId, methods]);
+  // categories.length and methods intentionally omitted: including them
+  // would reset the form whenever categories finish loading or methods
+  // re-renders, which breaks the open-modal editing experience.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, product?._id, isEdit, selectedCategoryId, onOpenChange]);
 
   const [unit, categoryId, addToCart] = methods.watch(['unit', 'categoryId', 'addToCart']);
 

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -16,7 +16,7 @@ interface CategoriesContextType {
   fetchCategories: () => Promise<void>;
   removeCategory: (id: string) => Promise<void>;
   setSelectedCategoryId: (categoryId: string) => void;
-  setCategories: (categories: CategoryProps[]) => void;
+  setCategories: React.Dispatch<React.SetStateAction<CategoryProps[]>>;
   addCategory: (category: CategoryProps) => Promise<void>;
 }
 

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -49,11 +49,11 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
 
     const { data } = await response.json();
 
-    const updatedCategories = [...categories, data].sort((categoryA, categoryB) =>
-      categoryA.name.localeCompare(categoryB.name, 'pt-BR', { sensitivity: 'base' })
+    setCategories(prev =>
+      [...prev, data].sort((categoryA, categoryB) =>
+        categoryA.name.localeCompare(categoryB.name, 'pt-BR', { sensitivity: 'base' })
+      )
     );
-
-    setCategories(updatedCategories);
     toast('Categoria criada com sucesso');
   };
 
@@ -70,7 +70,7 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
     const status = response.status;
 
     if (status === 204) {
-      setCategories(categories.filter(category => category._id !== id));
+      setCategories(prev => prev.filter(category => category._id !== id));
 
       toast('Categoria removida com sucesso');
     }

--- a/src/context/ProductContext.tsx
+++ b/src/context/ProductContext.tsx
@@ -116,7 +116,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
         );
 
         if (oldCategory && oldCategory._id !== updatedProduct.category._id) {
-          setCategories(categories.map(category => {
+          setCategories(prev => prev.map(category => {
 
             if (category._id === oldCategory._id) {
               return {
@@ -135,7 +135,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
             return category;
           }));
         } else {
-          setCategories(categories.map(category => ({
+          setCategories(prev => prev.map(category => ({
             ...category,
             products: category?.products?.map(product =>
               product?._id === updatedProduct?._id ? updatedProduct : product
@@ -160,7 +160,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
         const newProduct = await response.json();
         const productCategory = categories.find(category => category._id === newProduct.category._id);
 
-        setCategories(categories.map(category => ({
+        setCategories(prev => prev.map(category => ({
           ...category,
           products: category?._id === newProduct.category?._id ? [...category.products || [], newProduct] : category.products
         })));
@@ -171,6 +171,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
+      throw err;
     } finally {
       setIsProductLoading({ productId: null, isLoading: false });
     }
@@ -194,7 +195,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
 
       const category = categories.find(category => category.products?.some(product => product._id === id));
 
-      setCategories(categories.map(category => ({
+      setCategories(prev => prev.map(category => ({
         ...category,
         products: category.products?.filter(product => product._id !== id)
       })));
@@ -214,7 +215,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
         fetch(`/api/products/${product._id}`, { method: 'DELETE' })
       ));
 
-      setCategories(categories.map(category => ({
+      setCategories(prev => prev.map(category => ({
         ...category,
         products: []
       })));
@@ -248,7 +249,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
 
       const updatedProduct = await response.json();
 
-      setCategories(categories.map(category => ({
+      setCategories(prev => prev.map(category => ({
         ...category,
         products: category.products?.map(product => product._id === id ? updatedProduct : product)
       })));


### PR DESCRIPTION
## Summary

- `onSubmit` no `ProductManagerSheet` agora é `async`: faz `await managerProduct()` e só fecha o modal no sucesso — eliminando o cenário onde o modal fechava antes de saber o resultado da operação
- Todas as chamadas `setCategories` em `ProductContext` e `CategoryContext` migradas para functional updates (`prev => prev.map/filter(...)`) — eliminando stale closure que poderia sobrescrever o estado atual com dados obsoletos
- `managerProduct` agora relança o erro após o catch, permitindo que o caller reaja à falha
- Fetch de edição falha com `toast.error` + fecha modal, em vez de `console.error` silencioso (campos vazios sem feedback)
- Deps do `useEffect` corrigidas: removidos `categories.length` e `methods` (causavam reset do formulário ao adicionar/remover categorias com o modal aberto); `onOpenChange` adicionado corretamente
- Type `setCategories` atualizado para `React.Dispatch<React.SetStateAction<CategoryProps[]>>` para aceitar functional updaters

## Bugs corrigidos

**Criação:** toast de erro aparecia mesmo quando o produto era criado com sucesso (modal fechava antes da resposta da API)

**Edição:** modal abria com campos vazios após o app voltar do background (fetch do produto era abortado e reiniciado por deps erradas no useEffect; falha silenciosa sem feedback)

## Test Plan

- [ ] Criar produto → modal fecha, produto aparece na lista, toast de sucesso
- [ ] Editar produto → modal abre com campos preenchidos corretamente
- [ ] Simular falha de rede (DevTools offline) ao criar → modal permanece aberto com dados, toast de erro
- [ ] Simular falha de rede ao abrir edição → modal fecha com toast de erro (não fica vazio)
- [ ] Bloquear tela / trocar de app / voltar → fluxos de criação e edição funcionam normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)