### PR TITLE
feat: add real-time sync between devices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Firebase Admin SDK (server-only — não incluir no client bundle)
+AUTH_FIREBASE_PROJECT_ID=
+AUTH_FIREBASE_CLIENT_EMAIL=
+AUTH_FIREBASE_PRIVATE_KEY=
+
+# Firebase client SDK (público — prefixo NEXT_PUBLIC_ obrigatório)
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+
+# Apenas em desenvolvimento — não definir em produção
+FIREBASE_AUTH_EMULATOR_HOST=localhost:9099

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docs/superpowers/plans/2026-06-08-realtime-sync.md
+++ b/docs/superpowers/plans/2026-06-08-realtime-sync.md
@@ -1,0 +1,1073 @@
+# Real-time Sync entre Dispositivos — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permitir que alterações feitas em um dispositivo sejam refletidas automaticamente em todos os outros dispositivos conectados à mesma conta, com toast "Lista atualizada" para mudanças remotas.
+
+**Architecture:** O Firebase client SDK é adicionado ao browser para abrir listeners `onSnapshot` nas coleções `categories` e `products`. O `CategoriesContextProvider` gerencia o ciclo de vida dos listeners. Todas as escritas continuam passando pelas API routes existentes sem nenhuma mudança. Um novo endpoint `/api/auth/firebase-token` gera um custom token que autentica o cliente no Firebase para leituras.
+
+**Tech Stack:** Firebase client SDK (`firebase`), Firebase Admin SDK (`firebase-admin` — já instalado), NextAuth.js, React Context API, Sonner (toasts — já instalado)
+
+---
+
+## File Map
+
+| Arquivo | Ação | Responsabilidade |
+|---|---|---|
+| `src/lib/firebase-client.ts` | Criar | Singleton do Firebase client app, auth e db |
+| `src/app/api/auth/firebase-token/route.ts` | Criar | Endpoint que gera custom token Firebase |
+| `src/hooks/useFirebaseAuth.ts` | Criar | Hook que autentica o cliente no Firebase |
+| `src/context/CategoryContext.tsx` | Modificar | Substituir fetch por onSnapshot + isLocalMutationCount + markLocalMutation |
+| `src/context/ProductContext.tsx` | Modificar | Chamar markLocalMutation() antes de cada mutation |
+| `firebase.json` | Modificar | Adicionar Auth Emulator para desenvolvimento |
+| `firestore.rules` | Criar | Security Rules para leituras client-side |
+| `.env.local` | Modificar | Variáveis NEXT_PUBLIC_ + FIREBASE_AUTH_EMULATOR_HOST |
+
+---
+
+## Task 1: Instalar firebase client SDK e configurar ambiente
+
+**Files:**
+- Modify: `package.json` (via npm install)
+- Modify: `.env.local`
+- Modify: `firebase.json`
+
+- [ ] **Step 1: Instalar firebase client SDK**
+
+No diretório do worktree (`easy-list/.claude/worktrees/feat+realtime-sync`):
+
+```bash
+npm install firebase
+```
+
+Resultado esperado: `firebase` aparece em `dependencies` no `package.json`.
+
+- [ ] **Step 2: Adicionar variáveis de ambiente ao `.env.local`**
+
+Abra o Firebase Console → Project Settings → General → Your apps → Web app.
+Adicione ao final do `.env.local` na raiz do projeto:
+
+```env
+# Firebase client SDK (público — usado no browser)
+NEXT_PUBLIC_FIREBASE_API_KEY=<valor do console>
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=<valor do console>
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=<valor do console>
+
+# Auth Emulator — só necessário em desenvolvimento
+FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
+```
+
+> Em desenvolvimento com o emulator, os valores de `NEXT_PUBLIC_FIREBASE_*` podem ser quaisquer strings não-vazias (ex: `easy-list-local` para o project ID). O emulator não valida as credenciais.
+
+- [ ] **Step 3: Adicionar Auth Emulator ao `firebase.json`**
+
+Substitua o conteúdo de `firebase.json` por:
+
+```json
+{
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "singleProjectMode": true
+  }
+}
+```
+
+- [ ] **Step 4: Verificar que o emulator sobe com auth**
+
+```bash
+npx firebase emulators:start
+```
+
+Resultado esperado: linhas como:
+```
+✔  firestore: Emulator started at http://127.0.0.1:8080
+✔  auth: Emulator started at http://127.0.0.1:9099
+✔  All emulators ready!
+```
+
+Pressione `Ctrl+C` para parar.
+
+- [ ] **Step 5: Criar `.env.example` com as novas variáveis**
+
+Crie o arquivo `.env.example` na raiz do projeto com o template das variáveis necessárias:
+
+```env
+# Firebase Admin SDK (server-only — não incluir no client bundle)
+AUTH_FIREBASE_PROJECT_ID=
+AUTH_FIREBASE_CLIENT_EMAIL=
+AUTH_FIREBASE_PRIVATE_KEY=
+
+# Firebase client SDK (público — prefixo NEXT_PUBLIC_ obrigatório)
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+
+# Apenas em desenvolvimento — não definir em produção
+FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add firebase.json package.json package-lock.json .env.example
+git commit -m "chore: install firebase client SDK and configure auth emulator"
+```
+
+---
+
+## Task 2: Criar `src/lib/firebase-client.ts`
+
+**Files:**
+- Create: `src/lib/firebase-client.ts`
+
+- [ ] **Step 1: Criar o arquivo**
+
+Crie `src/lib/firebase-client.ts` com o seguinte conteúdo:
+
+```ts
+import { getApp, getApps, initializeApp } from 'firebase/app';
+import { connectAuthEmulator, getAuth } from 'firebase/auth';
+import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
+
+const clientConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+};
+
+const app = getApps().length ? getApp() : initializeApp(clientConfig);
+
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+
+if (process.env.NODE_ENV === 'development') {
+  try {
+    connectFirestoreEmulator(db, 'localhost', 8080);
+    connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
+  } catch {
+    // Emulators already connected (HMR re-execution)
+  }
+}
+```
+
+- [ ] **Step 2: Verificar que o TypeScript compila sem erros**
+
+```bash
+npx tsc --noEmit
+```
+
+Resultado esperado: nenhum erro relacionado ao arquivo criado.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/firebase-client.ts
+git commit -m "feat: add firebase client SDK initialization"
+```
+
+---
+
+## Task 3: Criar endpoint `GET /api/auth/firebase-token`
+
+**Files:**
+- Create: `src/app/api/auth/firebase-token/route.ts`
+
+- [ ] **Step 1: Criar o arquivo**
+
+Crie `src/app/api/auth/firebase-token/route.ts`:
+
+```ts
+import { getAuth } from 'firebase-admin/auth';
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authSecret } from '@/lib/auth-secret';
+
+export async function GET(request: NextRequest) {
+  const token = await getToken({ req: request, secret: authSecret });
+  const userId = token?.sub ?? null;
+
+  if (!userId) {
+    return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+  }
+
+  try {
+    const firebaseToken = await getAuth().createCustomToken(userId);
+
+    return NextResponse.json({ token: firebaseToken }, { status: 200 });
+  } catch (error) {
+    console.error('Failed to create Firebase custom token:', error);
+
+    return NextResponse.json({ error: 'Erro ao gerar token' }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 2: Verificar que o TypeScript compila sem erros**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Testar o endpoint manualmente**
+
+Com o emulator rodando (`npx firebase emulators:start`) e o Next.js rodando (`npm run dev`), abra o browser com sessão ativa e acesse no console do browser:
+
+```js
+const res = await fetch('/api/auth/firebase-token')
+const data = await res.json()
+console.log(data) // { token: "eyJ..." }
+```
+
+Resultado esperado: objeto com campo `token` (string JWT longa).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/auth/firebase-token/route.ts
+git commit -m "feat: add firebase custom token endpoint"
+```
+
+---
+
+## Task 4: Criar hook `useFirebaseAuth`
+
+**Files:**
+- Create: `src/hooks/useFirebaseAuth.ts`
+
+- [ ] **Step 1: Criar o arquivo**
+
+Crie `src/hooks/useFirebaseAuth.ts`:
+
+```ts
+'use client';
+
+import { signInWithCustomToken } from 'firebase/auth';
+import { useSession } from 'next-auth/react';
+import { useState, useEffect } from 'react';
+
+import { auth } from '@/lib/firebase-client';
+import { AuthStatusEnum } from '@/types/enums';
+
+export function useFirebaseAuth() {
+  const { status: sessionStatus } = useSession();
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    if (sessionStatus !== AuthStatusEnum.authenticated) return;
+
+    let cancelled = false;
+
+    async function authenticate() {
+      try {
+        const response = await fetch('/api/auth/firebase-token');
+
+        if (!response.ok) return;
+
+        const { token } = await response.json();
+
+        await signInWithCustomToken(auth, token);
+
+        if (!cancelled) {
+          setIsReady(true);
+        }
+      } catch (error) {
+        console.error('Firebase auth failed:', error);
+      }
+    }
+
+    authenticate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionStatus]);
+
+  return { isReady };
+}
+```
+
+- [ ] **Step 2: Verificar que o TypeScript compila sem erros**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Testar manualmente**
+
+Com o emulator e Next.js rodando, adicione temporariamente no `CategoriesContextProvider` (só para teste):
+
+```ts
+import { useFirebaseAuth } from '@/hooks/useFirebaseAuth';
+// dentro do componente:
+const { isReady } = useFirebaseAuth();
+console.log('Firebase auth ready:', isReady);
+```
+
+Abra o browser, logue na aplicação. No console do browser você deve ver:
+```
+Firebase auth ready: false
+Firebase auth ready: true
+```
+
+Remova o `console.log` após verificar.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useFirebaseAuth.ts
+git commit -m "feat: add useFirebaseAuth hook for client-side Firebase authentication"
+```
+
+---
+
+## Task 5: Adicionar `markLocalMutation` à interface e ao `CategoriesContextProvider`
+
+**Files:**
+- Modify: `src/context/CategoryContext.tsx`
+
+Esta tarefa é incremental: adiciona somente a ref e o método ao contexto, sem tocar na lógica de fetch/snapshot ainda.
+
+- [ ] **Step 1: Adicionar `markLocalMutation` à interface `CategoriesContextType`**
+
+Em `src/context/CategoryContext.tsx`, localize a interface `CategoriesContextType` (linha 10) e adicione o campo:
+
+```ts
+interface CategoriesContextType {
+  categories: CategoryProps[];
+  selectedCategoryId?: string;
+  isLoadingCategories: boolean;
+  errorCategories: string | null;
+  filteredCategory?: CategoryProps;
+  fetchCategories: () => Promise<void>;
+  removeCategory: (id: string) => Promise<void>;
+  setSelectedCategoryId: (categoryId: string) => void;
+  setCategories: React.Dispatch<React.SetStateAction<CategoryProps[]>>;
+  addCategory: (category: CategoryProps) => Promise<void>;
+  markLocalMutation: (count?: number) => void;
+}
+```
+
+- [ ] **Step 2: Adicionar a ref e o callback dentro do `CategoriesContextProvider`**
+
+Logo após as declarações de estado existentes (após a linha `const [filteredCategory, setFilteredCategory] = ...`), adicione:
+
+```ts
+const localMutationCount = useRef(0);
+
+const markLocalMutation = useCallback((count = 1) => {
+  localMutationCount.current += count;
+}, []);
+```
+
+Lembre de adicionar `useRef` ao import do React se ainda não estiver:
+
+```ts
+import React, { useState, useEffect, useContext, useCallback, createContext, useRef } from 'react';
+```
+
+- [ ] **Step 3: Expor `markLocalMutation` no valor do contexto**
+
+Localize o `<CategoriesContext.Provider value={{...}}>` e adicione `markLocalMutation`:
+
+```ts
+<CategoriesContext.Provider
+  value={{
+    categories,
+    addCategory,
+    setCategories,
+    removeCategory,
+    fetchCategories,
+    errorCategories,
+    filteredCategory,
+    selectedCategoryId,
+    isLoadingCategories,
+    setSelectedCategoryId,
+    markLocalMutation,
+  }}
+>
+```
+
+- [ ] **Step 4: Verificar que o TypeScript compila**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/context/CategoryContext.tsx
+git commit -m "feat: expose markLocalMutation in CategoriesContext"
+```
+
+---
+
+## Task 6: Substituir `fetchCategories` por `onSnapshot` no `CategoriesContextProvider`
+
+**Files:**
+- Modify: `src/context/CategoryContext.tsx`
+
+Esta é a tarefa central. O arquivo `CategoryContext.tsx` será significativamente modificado. O conteúdo completo do arquivo após esta tarefa deve ser:
+
+- [ ] **Step 1: Substituir o conteúdo de `src/context/CategoryContext.tsx`**
+
+```tsx
+'use client';
+
+import { toast } from 'sonner';
+import { Timestamp, collection, onSnapshot, query, where } from 'firebase/firestore';
+import { useSession } from 'next-auth/react';
+import React, { useState, useEffect, useContext, useCallback, createContext, useRef } from 'react';
+
+import { AuthStatusEnum } from '@/types/enums';
+import { CategoryProps, ProductProps } from '@/types/interfaces';
+import { auth, db } from '@/lib/firebase-client';
+import { useFirebaseAuth } from '@/hooks/useFirebaseAuth';
+
+interface RawCategory {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RawProduct {
+  id: string;
+  name: string;
+  categoryId: string;
+  price?: string;
+  quantity?: string;
+  unit?: string;
+  addToCart?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CategoriesContextType {
+  categories: CategoryProps[];
+  selectedCategoryId?: string;
+  isLoadingCategories: boolean;
+  errorCategories: string | null;
+  filteredCategory?: CategoryProps;
+  fetchCategories: () => Promise<void>;
+  removeCategory: (id: string) => Promise<void>;
+  setSelectedCategoryId: (categoryId: string) => void;
+  setCategories: React.Dispatch<React.SetStateAction<CategoryProps[]>>;
+  addCategory: (category: CategoryProps) => Promise<void>;
+  markLocalMutation: (count?: number) => void;
+}
+
+interface CategoryProviderProps {
+  children: React.ReactNode;
+}
+
+export const CategoriesContext = createContext({} as CategoriesContextType);
+
+function timestampToIso(value: unknown): string {
+  if (value instanceof Timestamp) return value.toDate().toISOString();
+  if (value instanceof Date) return value.toISOString();
+  return new Date().toISOString();
+}
+
+function CategoriesContextProvider({ children }: CategoryProviderProps) {
+  const { status: sessionStatus } = useSession();
+  const { isReady } = useFirebaseAuth();
+
+  const [categories, setCategories] = useState<CategoryProps[]>([]);
+  const [errorCategories, setErrorCategories] = useState<string | null>(null);
+  const [isLoadingCategories, setIsLoadingCategories] = useState<boolean>(true);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | undefined>(undefined);
+  const [filteredCategory, setFilteredCategory] = useState<CategoryProps | undefined>(undefined);
+
+  const localMutationCount = useRef(0);
+  const latestCategoriesRef = useRef<RawCategory[]>([]);
+  const latestProductsRef = useRef<RawProduct[]>([]);
+  const pendingInitialSnapshots = useRef(2);
+
+  const markLocalMutation = useCallback((count = 1) => {
+    localMutationCount.current += count;
+  }, []);
+
+  const buildCategoriesFromRefs = useCallback((): CategoryProps[] => {
+    const cats = latestCategoriesRef.current;
+    const prods = latestProductsRef.current;
+
+    return cats
+      .map((cat): CategoryProps => {
+        const catRef: CategoryProps = {
+          _id: cat.id,
+          name: cat.name,
+          createdAt: cat.createdAt,
+          updatedAt: cat.updatedAt,
+        };
+
+        const products: ProductProps[] = prods
+          .filter((p) => p.categoryId === cat.id)
+          .map((p) => ({
+            _id: p.id,
+            name: p.name,
+            price: p.price,
+            quantity: p.quantity,
+            unit: p.unit,
+            categoryId: p.categoryId,
+            addToCart: Boolean(p.addToCart),
+            createdAt: p.createdAt,
+            updatedAt: p.updatedAt,
+            category: catRef,
+          }))
+          .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'pt-BR'));
+
+        return { ...catRef, products };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name, 'pt-BR', { sensitivity: 'base' }));
+  }, []);
+
+  const handleSnapshotUpdate = useCallback(
+    (isInitial: boolean) => {
+      const rebuilt = buildCategoriesFromRefs();
+      setCategories(rebuilt);
+
+      if (pendingInitialSnapshots.current === 0) {
+        setIsLoadingCategories(false);
+      }
+
+      if (isInitial) return;
+
+      if (localMutationCount.current > 0) {
+        localMutationCount.current -= 1;
+        return;
+      }
+
+      toast('Lista atualizada');
+    },
+    [buildCategoriesFromRefs]
+  );
+
+  useEffect(() => {
+    if (!isReady || sessionStatus !== AuthStatusEnum.authenticated) return;
+
+    const userId = auth.currentUser?.uid;
+    if (!userId) return;
+
+    pendingInitialSnapshots.current = 2;
+
+    const categoriesQuery = query(
+      collection(db, 'categories'),
+      where('userId', '==', userId)
+    );
+
+    const productsQuery = query(
+      collection(db, 'products'),
+      where('userId', '==', userId)
+    );
+
+    const unsubCategories = onSnapshot(
+      categoriesQuery,
+      (snapshot) => {
+        const isInitial = pendingInitialSnapshots.current > 0;
+        if (isInitial) pendingInitialSnapshots.current -= 1;
+
+        latestCategoriesRef.current = snapshot.docs.map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            name: data.name as string,
+            createdAt: timestampToIso(data.createdAt),
+            updatedAt: timestampToIso(data.updatedAt),
+          };
+        });
+
+        handleSnapshotUpdate(isInitial);
+      },
+      (error) => {
+        console.error('Categories listener error:', error);
+        setErrorCategories(error.message);
+      }
+    );
+
+    const unsubProducts = onSnapshot(
+      productsQuery,
+      (snapshot) => {
+        const isInitial = pendingInitialSnapshots.current > 0;
+        if (isInitial) pendingInitialSnapshots.current -= 1;
+
+        latestProductsRef.current = snapshot.docs.map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            name: data.name as string,
+            categoryId: data.categoryId as string,
+            price: data.price as string | undefined,
+            quantity: data.quantity as string | undefined,
+            unit: data.unit as string | undefined,
+            addToCart: data.addToCart as boolean | undefined,
+            createdAt: timestampToIso(data.createdAt),
+            updatedAt: timestampToIso(data.updatedAt),
+          };
+        });
+
+        handleSnapshotUpdate(isInitial);
+      },
+      (error) => {
+        console.error('Products listener error:', error);
+        setErrorCategories(error.message);
+      }
+    );
+
+    return () => {
+      unsubCategories();
+      unsubProducts();
+    };
+  }, [isReady, sessionStatus, handleSnapshotUpdate]);
+
+  const addCategory = async (category: CategoryProps) => {
+    markLocalMutation();
+
+    const response = await fetch('/api/categories', {
+      method: 'POST',
+      body: JSON.stringify(category),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) {
+      localMutationCount.current -= 1;
+      toast('Erro ao criar categoria');
+      throw new Error('Failed to create category');
+    }
+
+    toast('Categoria criada com sucesso');
+  };
+
+  const removeCategory = async (id: string) => {
+    const productCount = categories.find((c) => c._id === id)?.products?.length ?? 0;
+    markLocalMutation(1 + productCount);
+
+    const response = await fetch(`/api/categories?id=${id}`, {
+      method: 'DELETE',
+    });
+
+    if (!response.ok) {
+      localMutationCount.current -= (1 + productCount);
+      toast('Erro ao remover categoria');
+      return;
+    }
+
+    if (response.status === 204) {
+      toast('Categoria removida com sucesso');
+    }
+  };
+
+  const fetchCategories = useCallback(async () => {
+    // No-op: initial load is handled by onSnapshot
+  }, []);
+
+  const filterCategory = useCallback(
+    (categoryId: string) => {
+      if (!categoryId || categoryId === 'all') {
+        setFilteredCategory(undefined);
+        return;
+      }
+      const found = categories.find((category) => category?._id === categoryId);
+      setFilteredCategory(found);
+    },
+    [categories]
+  );
+
+  useEffect(() => {
+    if (filteredCategory) {
+      filterCategory(filteredCategory._id);
+    }
+  }, [categories, filterCategory, filteredCategory]);
+
+  useEffect(() => {
+    if (
+      sessionStatus === AuthStatusEnum.loading ||
+      sessionStatus === AuthStatusEnum.unauthenticated
+    ) {
+      return;
+    }
+
+    if (selectedCategoryId && categories.length > 0) {
+      const category = categories.find((c) => c._id === selectedCategoryId);
+
+      if (!category) {
+        toast('Categoria não encontrada');
+        return;
+      }
+
+      setFilteredCategory(category);
+    }
+  }, [selectedCategoryId, categories, sessionStatus]);
+
+  return (
+    <CategoriesContext.Provider
+      value={{
+        categories,
+        addCategory,
+        setCategories,
+        removeCategory,
+        fetchCategories,
+        errorCategories,
+        filteredCategory,
+        selectedCategoryId,
+        isLoadingCategories,
+        setSelectedCategoryId,
+        markLocalMutation,
+      }}
+    >
+      {children}
+    </CategoriesContext.Provider>
+  );
+}
+
+function useCategories(): CategoriesContextType {
+  const context = useContext(CategoriesContext);
+
+  if (!context) {
+    throw new Error('useCategories must be used within a CategoriesProvider');
+  }
+  return context;
+}
+
+export { useCategories, CategoriesContextProvider };
+```
+
+- [ ] **Step 2: Verificar que o TypeScript compila**
+
+```bash
+npx tsc --noEmit
+```
+
+Resultado esperado: zero erros.
+
+- [ ] **Step 3: Verificar lint**
+
+```bash
+npm run lint
+```
+
+Resultado esperado: zero erros.
+
+- [ ] **Step 4: Testar carregamento inicial**
+
+Com emulators e Next.js rodando, logue na aplicação. A lista de categorias deve aparecer normalmente (mesmos dados de antes). O loading spinner deve sumir após o carregamento.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/context/CategoryContext.tsx
+git commit -m "feat: replace fetchCategories with Firestore onSnapshot real-time listeners"
+```
+
+---
+
+## Task 7: Chamar `markLocalMutation()` nas mutations do `ProductContext`
+
+**Files:**
+- Modify: `src/context/ProductContext.tsx`
+
+As mutations de produto precisam sinalizar ao listener que a próxima snapshot é local, evitando o toast "Lista atualizada" no próprio dispositivo.
+
+- [ ] **Step 1: Adicionar `markLocalMutation` ao destructuring de `useCategories()`**
+
+Localize a linha (linha 43):
+
+```ts
+const { categories, setCategories, selectedCategoryId } = useCategories();
+```
+
+Substitua por:
+
+```ts
+const { categories, setCategories, selectedCategoryId, markLocalMutation } = useCategories();
+```
+
+- [ ] **Step 2: Adicionar `markLocalMutation()` em `managerProduct` (criar produto)**
+
+Localize o trecho que cria produto (sem `product._id`), linha ~148:
+
+```ts
+} else {
+  const response = await fetch('/api/products', {
+```
+
+Adicione a chamada antes do fetch:
+
+```ts
+} else {
+  markLocalMutation();
+  const response = await fetch('/api/products', {
+```
+
+- [ ] **Step 3: Adicionar `markLocalMutation()` em `managerProduct` (atualizar produto)**
+
+Localize o trecho que atualiza produto (com `product._id`), linha ~99:
+
+```ts
+if (product._id) {
+  const response = await fetch(`/api/products/${product._id}`, {
+    method: 'PUT',
+```
+
+Adicione antes do fetch:
+
+```ts
+if (product._id) {
+  markLocalMutation();
+  const response = await fetch(`/api/products/${product._id}`, {
+    method: 'PUT',
+```
+
+- [ ] **Step 4: Adicionar `markLocalMutation()` em `removeProduct`**
+
+Localize a função `removeProduct` (linha ~180):
+
+```ts
+const removeProduct = async (id: string) => {
+  try {
+    setIsProductLoading({ productId: id, isLoading: true });
+
+    const response = await fetch(`/api/products/${id}`, {
+```
+
+Adicione após `setIsProductLoading`:
+
+```ts
+const removeProduct = async (id: string) => {
+  try {
+    setIsProductLoading({ productId: id, isLoading: true });
+    markLocalMutation();
+
+    const response = await fetch(`/api/products/${id}`, {
+```
+
+- [ ] **Step 5: Adicionar `markLocalMutation()` em `removeAllProducts`**
+
+Localize a função `removeAllProducts` (linha ~212):
+
+```ts
+const removeAllProducts = async () => {
+  try {
+    await Promise.all(categories.flatMap(category => category.products || []).map(product =>
+      fetch(`/api/products/${product._id}`, { method: 'DELETE' })
+    ));
+```
+
+Substitua por:
+
+```ts
+const removeAllProducts = async () => {
+  try {
+    const allProducts = categories.flatMap((category) => category.products || []);
+    markLocalMutation(allProducts.length);
+
+    await Promise.all(
+      allProducts.map((product) =>
+        fetch(`/api/products/${product._id}`, { method: 'DELETE' })
+      )
+    );
+```
+
+- [ ] **Step 6: Adicionar `markLocalMutation()` em `toggleCart`**
+
+Localize a função `toggleCart` (linha ~228), logo após `setIsProductLoading`:
+
+```ts
+const toggleCart = async (id: string) => {
+  if (!id) return;
+
+  setIsProductLoading({ productId: id, isLoading: true });
+
+  try {
+    const product = categories.flatMap(...)
+```
+
+Adicione após `setIsProductLoading`:
+
+```ts
+const toggleCart = async (id: string) => {
+  if (!id) return;
+
+  setIsProductLoading({ productId: id, isLoading: true });
+  markLocalMutation();
+
+  try {
+    const product = categories.flatMap(...)
+```
+
+- [ ] **Step 7: Verificar TypeScript e lint**
+
+```bash
+npx tsc --noEmit && npm run lint
+```
+
+Resultado esperado: zero erros.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/context/ProductContext.tsx
+git commit -m "feat: call markLocalMutation before each product mutation to suppress local-change toasts"
+```
+
+---
+
+## Task 8: Criar Firestore Security Rules
+
+**Files:**
+- Create: `firestore.rules`
+
+As Security Rules autorizam leituras client-side pelo Firebase client SDK. Writes do servidor via Admin SDK ignoram estas rules.
+
+- [ ] **Step 1: Criar `firestore.rules` na raiz do projeto**
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    match /categories/{categoryId} {
+      allow read: if request.auth != null
+                  && request.auth.uid == resource.data.userId;
+      allow write: if false;
+    }
+
+    match /products/{productId} {
+      allow read: if request.auth != null
+                  && request.auth.uid == resource.data.userId;
+      allow write: if false;
+    }
+
+  }
+}
+```
+
+- [ ] **Step 2: Referenciar o arquivo no `firebase.json`**
+
+Atualize `firebase.json`:
+
+```json
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "singleProjectMode": true
+  }
+}
+```
+
+- [ ] **Step 3: Verificar que o emulator carrega as rules**
+
+```bash
+npx firebase emulators:start
+```
+
+Resultado esperado: linha contendo `Rules updated`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add firestore.rules firebase.json
+git commit -m "feat: add Firestore security rules for client-side reads"
+```
+
+---
+
+## Task 9: Verificação manual — sync em tempo real
+
+**Pré-requisitos:** Firebase emulators rodando (`npx firebase emulators:start`) e Next.js rodando (`npm run dev`) em terminais separados.
+
+- [ ] **Step 1: Logar na aplicação em duas abas do mesmo browser**
+
+Abra `http://localhost:3000` em duas abas. Logue com a mesma conta nas duas abas. Ambas devem mostrar a mesma lista.
+
+- [ ] **Step 2: Verificar que os listeners estão ativos**
+
+No console do browser da Aba 1, execute:
+
+```js
+// Deve retornar o usuário Firebase autenticado (não null)
+firebase.auth().currentUser
+// Ou verifique via:
+import('/api/auth/firebase-token').then(...)
+```
+
+Alternativamente, verifique o Firebase Emulator UI em `http://localhost:4000` — deve mostrar um usuário autenticado em Authentication.
+
+- [ ] **Step 3: Testar adição de produto**
+
+Na Aba 1: adicione um produto em qualquer categoria.
+
+Resultado esperado:
+- Aba 1: produto aparece na lista **sem** toast "Lista atualizada" (é mudança local)
+- Aba 2: produto aparece na lista **com** toast "Lista atualizada" (é mudança remota)
+
+- [ ] **Step 4: Testar edição de produto**
+
+Na Aba 2: edite o nome do produto recém-criado.
+
+Resultado esperado:
+- Aba 2: sem toast
+- Aba 1: toast "Lista atualizada", nome do produto atualizado
+
+- [ ] **Step 5: Testar remoção de produto**
+
+Na Aba 1: remova o produto.
+
+Resultado esperado:
+- Aba 1: sem toast, produto desaparece da lista
+- Aba 2: toast "Lista atualizada", produto desaparece da lista
+
+- [ ] **Step 6: Testar adição de categoria**
+
+Na Aba 2: adicione uma nova categoria.
+
+Resultado esperado:
+- Aba 2: categoria aparece sem toast
+- Aba 1: toast "Lista atualizada", nova categoria visível
+
+- [ ] **Step 7: Testar toggle do carrinho**
+
+Na Aba 1: marque um produto para o carrinho.
+
+Resultado esperado:
+- Aba 1: sem toast
+- Aba 2: toast "Lista atualizada", produto marcado no carrinho
+
+- [ ] **Step 8: Commit final**
+
+```bash
+git add .
+git commit -m "chore: complete realtime sync implementation and verification"
+```
+
+---
+
+## Notas para produção
+
+Antes de fazer deploy em produção:
+
+1. **Deploy das Security Rules:** `npx firebase deploy --only firestore:rules`
+2. **Variáveis de ambiente no Vercel:** adicionar `NEXT_PUBLIC_FIREBASE_API_KEY`, `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`, `NEXT_PUBLIC_FIREBASE_PROJECT_ID` (sem `FIREBASE_AUTH_EMULATOR_HOST`)
+3. **Service account:** confirmar que `AUTH_FIREBASE_CLIENT_EMAIL` e `AUTH_FIREBASE_PRIVATE_KEY` estão configurados no Vercel (necessários para `createCustomToken` em produção)

--- a/docs/superpowers/specs/2026-06-08-realtime-sync-design.md
+++ b/docs/superpowers/specs/2026-06-08-realtime-sync-design.md
@@ -1,0 +1,229 @@
+# Real-time Sync entre Dispositivos — Design Spec
+
+**Data:** 2026-06-08
+**Branch:** feat/realtime-sync
+**Status:** Aprovado — aguardando implementação
+
+---
+
+## Problema
+
+Quando um usuário atualiza a lista em um dispositivo, a mudança não é refletida automaticamente nos outros dispositivos conectados à mesma conta. A lista só é atualizada quando o usuário recarrega manualmente a aplicação.
+
+---
+
+## Contexto técnico atual
+
+- **Backend:** Firebase Firestore via Admin SDK (server-only)
+- **State management:** React Context API (`CategoriesContextProvider`, `ProductsContextProvider`)
+- **Carregamento inicial:** `fetchCategories()` em `CategoriesContextProvider` faz um único `GET /api/categories` na montagem
+- **Mutations:** API routes (`/api/categories`, `/api/products`, `/api/products/[id]`) escrevem no Firestore via Admin SDK e atualizam o estado local otimisticamente
+- **Sincronização atual:** Nenhuma — sem polling, WebSocket, SSE ou listeners real-time
+- **Hospedagem:** Vercel (serverless)
+
+---
+
+## Decisões de design
+
+| Questão | Decisão |
+|---|---|
+| Comportamento no dispositivo remoto | Atualização automática + toast "Lista atualizada" |
+| Escopo do sync | Somente enquanto a lista está aberta (componente montado) |
+| Conflito de edição simultânea | Última escrita vence (sem detecção explícita) |
+| Hospedagem | Vercel — descarta SSE por limitação de timeout serverless |
+| Abordagem escolhida | Firebase client SDK + `onSnapshot` |
+
+---
+
+## Arquitetura
+
+### Princípio central
+
+**Writes** continuam exclusivamente via API routes com Admin SDK — sem nenhuma mudança nas mutations existentes.
+
+**Reads em real-time** são responsabilidade do Firebase client SDK no browser, autenticado via custom token.
+
+### Fluxo completo
+
+```
+Login (NextAuth)
+  ↓
+GET /api/auth/firebase-token
+  ↓ custom token (Admin SDK: createCustomToken(userId))
+signInWithCustomToken(auth, token)
+  ↓ sessão Firebase client-side ativa
+onSnapshot(categories + products filtrados por userId)
+  ↓ mudança detectada (de qualquer dispositivo)
+setCategories(novosDados)
+  ↓
+toast("Lista atualizada")  ← só se mudança for remota
+```
+
+### Separação de responsabilidades
+
+```
+Writes:  Cliente → API Route → Admin SDK → Firestore
+Reads:   Firestore → onSnapshot (client SDK) → Context → UI
+```
+
+---
+
+## Componentes novos
+
+### `src/lib/firebase-client.ts`
+
+Inicializa o Firebase client SDK uma única vez. Exporta `auth` e `db` (Firestore client) para uso nos listeners.
+
+```ts
+// Inicialização com as mesmas credenciais públicas do projeto Firebase
+// (NEXT_PUBLIC_FIREBASE_API_KEY, etc.)
+export const app = initializeApp(clientConfig)
+export const auth = getAuth(app)
+export const db   = getFirestore(app)
+```
+
+### `src/app/api/auth/firebase-token/route.ts`
+
+Endpoint protegido por sessão NextAuth. Gera e retorna um custom token Firebase para o usuário autenticado.
+
+```
+GET /api/auth/firebase-token
+→ 401 se sem sessão
+→ 200 { token: string } se autenticado
+```
+
+Usa `admin.auth().createCustomToken(userId)` — o mesmo `userId` já presente em todas as queries Firestore.
+
+### `src/hooks/useFirebaseAuth.ts`
+
+Hook chamado uma única vez no `CategoriesContextProvider`. Responsável por:
+
+1. Buscar o custom token via `GET /api/auth/firebase-token`
+2. Chamar `signInWithCustomToken(auth, token)`
+3. Retornar estado `{ isReady: boolean }` para habilitar os listeners
+
+### Modificações em `src/context/CategoryContext.tsx`
+
+- Substituir o `fetchCategories()` inicial por dois listeners `onSnapshot`:
+  - `collection('categories') where('userId', '==', userId)`
+  - `collection('products') where('userId', '==', userId)`
+- Reconstrói o shape `CategoryProps[]` (categorias com produtos aninhados) a cada snapshot
+- Gerencia cleanup dos listeners no `useEffect` return
+
+---
+
+## Diferenciação: mudança local vs. remota
+
+Para exibir o toast apenas em mudanças de outros dispositivos:
+
+```ts
+const isLocalMutation = useRef(false)
+
+// Chamado antes de cada mutation no contexto:
+isLocalMutation.current = true
+
+// Handler do onSnapshot:
+if (isLocalMutation.current) {
+  isLocalMutation.current = false
+  return  // mudança própria — sem toast
+}
+// mudança remota → setCategories() + toast("Lista atualizada")
+```
+
+Não requer nenhum campo extra no Firestore.
+
+---
+
+## Firestore Security Rules
+
+Necessárias para autorizar leituras do browser via client SDK. Writes permanecem bloqueados do client — o Admin SDK no servidor ignora essas rules.
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    match /categories/{categoryId} {
+      allow read: if request.auth != null
+                  && request.auth.uid == resource.data.userId;
+      allow write: if false;
+    }
+
+    match /products/{productId} {
+      allow read: if request.auth != null
+                  && request.auth.uid == resource.data.userId;
+      allow write: if false;
+    }
+
+  }
+}
+```
+
+Deploy via `firebase deploy --only firestore:rules` ou Firebase Console.
+O Firebase Emulator (porta 8080) avalia as rules em desenvolvimento.
+
+---
+
+## UX: comportamento do toast
+
+| Evento | Toast exibido |
+|---|---|
+| Produto adicionado por outro dispositivo | "Lista atualizada" |
+| Produto editado por outro dispositivo | "Lista atualizada" |
+| Produto removido por outro dispositivo | "Lista atualizada" |
+| Categoria adicionada por outro dispositivo | "Lista atualizada" |
+| Categoria removida por outro dispositivo | "Lista atualizada" |
+| Mudança feita pelo próprio dispositivo | Nenhum toast |
+| Carregamento inicial da lista | Nenhum toast |
+
+O toast reutiliza o sistema de notificações já existente no projeto. Duração: ~3 segundos. Não-bloqueante.
+
+---
+
+## Tratamento de erros
+
+| Cenário | Comportamento |
+|---|---|
+| Falha ao buscar custom token | Listener não é aberto; lista funciona via fetch inicial (degradação silenciosa) |
+| Perda de conexão durante sessão | Firebase client SDK reconecta automaticamente e entrega mudanças acumuladas |
+| Erro no listener `onSnapshot` | Log no console + listener fechado graciosamente; estado em memória preservado |
+| Logout | `unsubscribe()` cancela listeners; `signOut(auth)` encerra sessão Firebase |
+
+**Princípio:** real-time é uma melhoria progressiva. Falhas no sync não quebram a experiência básica.
+
+---
+
+## Novas variáveis de ambiente necessárias
+
+```env
+# Firebase client SDK (públicas — prefixo NEXT_PUBLIC_)
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+```
+
+As credenciais de Admin SDK (`AUTH_FIREBASE_*`) já existem no projeto.
+
+---
+
+## Arquivos impactados
+
+| Arquivo | Tipo de mudança |
+|---|---|
+| `src/lib/firebase-client.ts` | Novo |
+| `src/app/api/auth/firebase-token/route.ts` | Novo |
+| `src/hooks/useFirebaseAuth.ts` | Novo |
+| `src/context/CategoryContext.tsx` | Modificado (fetch → onSnapshot + isLocalMutation) |
+| `src/context/ProductContext.tsx` | Modificado (expor helper isLocalMutation para mutations de produto) |
+| `firestore.rules` | Modificado (adicionar rules de read para categories e products) |
+| `.env.local` / `.env.example` | Modificado (novas variáveis NEXT_PUBLIC_) |
+| `package.json` | Modificado (adicionar dependência `firebase` client SDK) |
+
+---
+
+## Alternativas avaliadas e descartadas
+
+| Opção | Motivo do descarte |
+|---|---|
+| Polling (SWR/React Query com `refreshInterval`) | Não é real-time; consome API calls e Firestore reads mesmo sem mudanças |
+| SSE via Edge Runtime | Alta complexidade; sem estado compartilhado entre instâncias serverless (problema de broadcast) |

--- a/docs/superpowers/specs/2026-06-08-realtime-sync-design.md
+++ b/docs/superpowers/specs/2026-06-08-realtime-sync-design.md
@@ -114,13 +114,14 @@ Hook chamado uma única vez no `CategoriesContextProvider`. Responsável por:
 
 ## Diferenciação: mudança local vs. remota
 
-Para exibir o toast apenas em mudanças de outros dispositivos:
+Para exibir o toast apenas em mudanças de outros dispositivos, `CategoriesContextProvider` mantém uma ref de controle e expõe uma função `markLocalMutation()` via contexto:
 
 ```ts
+// CategoriesContextProvider
 const isLocalMutation = useRef(false)
-
-// Chamado antes de cada mutation no contexto:
-isLocalMutation.current = true
+const markLocalMutation = useCallback(() => {
+  isLocalMutation.current = true
+}, [])
 
 // Handler do onSnapshot:
 if (isLocalMutation.current) {
@@ -129,6 +130,13 @@ if (isLocalMutation.current) {
 }
 // mudança remota → setCategories() + toast("Lista atualizada")
 ```
+
+**Onde `markLocalMutation()` é chamado:**
+
+- `CategoryContext.tsx` — antes de cada `fetch` em `addCategory()` e `removeCategory()` (mutations já vivem neste contexto, acesso direto à ref)
+- `ProductContext.tsx` — antes de cada `fetch` em `managerProduct()`, `toggleCart()`, `removeProduct()` e `removeAllProducts()`. Esses métodos já consomem `useCategories()`, então `markLocalMutation` é obtido do mesmo hook sem acoplamento extra
+
+`CategoriesContextType` recebe o campo `markLocalMutation: () => void`.
 
 Não requer nenhum campo extra no Firestore.
 
@@ -176,7 +184,7 @@ O Firebase Emulator (porta 8080) avalia as rules em desenvolvimento.
 | Mudança feita pelo próprio dispositivo | Nenhum toast |
 | Carregamento inicial da lista | Nenhum toast |
 
-O toast reutiliza o sistema de notificações já existente no projeto. Duração: ~3 segundos. Não-bloqueante.
+Usa `toast()` do `sonner`, já instalado e em uso em `CategoryContext.tsx` e `ProductContext.tsx`. Sem nova dependência. Duração padrão do sonner (~4 segundos). Não-bloqueante.
 
 ---
 
@@ -213,8 +221,8 @@ As credenciais de Admin SDK (`AUTH_FIREBASE_*`) já existem no projeto.
 | `src/lib/firebase-client.ts` | Novo |
 | `src/app/api/auth/firebase-token/route.ts` | Novo |
 | `src/hooks/useFirebaseAuth.ts` | Novo |
-| `src/context/CategoryContext.tsx` | Modificado (fetch → onSnapshot + isLocalMutation) |
-| `src/context/ProductContext.tsx` | Modificado (expor helper isLocalMutation para mutations de produto) |
+| `src/context/CategoryContext.tsx` | Modificado (fetch → onSnapshot + `isLocalMutation` ref + `markLocalMutation` no contexto) |
+| `src/context/ProductContext.tsx` | Modificado (chamar `markLocalMutation()` antes de cada mutation) |
 | `firestore.rules` | Modificado (adicionar rules de read para categories e products) |
 | `.env.local` / `.env.example` | Modificado (novas variáveis NEXT_PUBLIC_) |
 | `package.json` | Modificado (adicionar dependência `firebase` client SDK) |

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,8 @@
 {
   "emulators": {
+    "auth": {
+      "port": 9099
+    },
     "firestore": {
       "port": 8080
     },

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,7 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "emulators": {
     "auth": {
       "port": 9099

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,18 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    match /categories/{categoryId} {
+      allow read: if request.auth != null
+                  && request.auth.uid == resource.data.userId;
+      allow write: if false;
+    }
+
+    match /products/{productId} {
+      allow read: if request.auth != null
+                  && request.auth.uid == resource.data.userId;
+      allow write: if false;
+    }
+
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "firebase": "^12.14.0",
         "firebase-admin": "^13.10.0",
         "lucide-react": "^0.469.0",
         "next": "15.3.8",
@@ -340,11 +341,145 @@
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
       "license": "MIT"
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.0.tgz",
+      "integrity": "sha512-nJJDQKqjAcbkZdZGT/5WTVLrGZ+pYhWbwKC90nNzmvtoRTtnOJaNS34fhKSHQeB9SALgD2kxuWT5I4AkytdZ/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.13.tgz",
+      "integrity": "sha512-H89Jeyp31+EZk9GPu6vaeL9mEmoXgM3nASB7UPBYYS/lqAks21mO1BU1dF8NbsVTL6tgGZkGUtiGJgxtDiwHkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.4.tgz",
+      "integrity": "sha512-G8EsbVJV9gSfoibx0dNoNOUrvr+PkL7J//+W/BST/oUassimkZeq9bjj3bKkB0pn4og5GMQ9qs7FefwP00kkgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.4.tgz",
+      "integrity": "sha512-9iP0MvmaVagulNXmrca96U3tqNAI3j98wsC1z7rj62nnOTajlrHM//jjB9VoHqRw6/islMskp6RsKnM7vhLDqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.4",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
     "node_modules/@firebase/app-check-interop-types": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
       "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.13.tgz",
+      "integrity": "sha512-pn3FvXwUR34kWPccDQfCKsNZcM2wD1OS+J1jeEgzM1ZNXoxR2NaF6e5DjDuRrnTwR6LN2XQQt0IqE6yKmgpCQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.13",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@firebase/app-types": {
       "version": "0.9.5",
@@ -355,11 +490,64 @@
         "@firebase/logger": "0.5.1"
       }
     },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.2.tgz",
+      "integrity": "sha512-B4w0iS7MxRg28oIh2fJFTE6cM0lYdBrW19eHpc42jqEcloUjlYyVrpPqZvqA4+v9KFEVSKEs2SfWyta7hbzkJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.7.tgz",
+      "integrity": "sha512-XgKnOgY1Siq7gylAmLkYtHAlRxNeWEAspH+nO3gJZJnfHqoTHbr9UjJ3nHNFALYXV5CfpQlyPROyB2ztySBHBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.2",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
     "node_modules/@firebase/auth-interop-types": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
       "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
     },
     "node_modules/@firebase/component": {
       "version": "0.7.3",
@@ -372,6 +560,22 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/database": {
@@ -419,6 +623,154 @@
         "@firebase/util": "1.15.1"
       }
     },
+    "node_modules/@firebase/firestore": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.15.0.tgz",
+      "integrity": "sha512-Fj9osqYkz2Rqr7kW3/A8BRd8CyJ7yA5K8YjhihRdyJWbL+FsELVcR6DpoCplrp1IyU+xeGgTubo1UOySXpY+EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.10.tgz",
+      "integrity": "sha512-yMP3FADDjikdrQv4YmvL4EkIny6Hw+N+a2O5T40rlHiniyMpRPxgYkKiFOvMZnsqKLqBVnKqCAElC0pa/IZtdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.15.0",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
     "node_modules/@firebase/logger": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
@@ -429,6 +781,169 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
+      "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.4.tgz",
+      "integrity": "sha512-lslywR5lGvHWTu4z/MPoYs3UwS3CKdeY+ELXY87087VsOpBpkD+9Orra23tA9GW683arPTDOM3CM6eKmtiOO3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.25.tgz",
+      "integrity": "sha512-FnA5S4IxFJAAFrCnYzWlO0FCaizlYdqhe42ygFMA+wE/mUP+w36iXzHyKj1OO1A+2gyMFjeRHyg8HhkJ6c5vRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.8.4",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
       }
     },
     "node_modules/@firebase/util": {
@@ -443,6 +958,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.6.9",
@@ -641,7 +1162,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -1443,36 +1963,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
       }
@@ -1481,36 +1996,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
       "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.0",
@@ -4990,7 +5500,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -5005,7 +5514,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5014,15 +5522,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5037,7 +5543,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5050,7 +5555,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5754,7 +6258,6 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -6600,6 +7103,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/firebase": {
+      "version": "12.14.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.14.0.tgz",
+      "integrity": "sha512-aEZ/lniDR1hOCYpx/x/V8Nrrqq9pepKDNkqP/4WGZFC69gTv6F59Z4/54W/SUP4L/hFlrRNmWj35aweQq+IHow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.13.0",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.14.13",
+        "@firebase/app-check": "0.11.4",
+        "@firebase/app-check-compat": "0.4.4",
+        "@firebase/app-compat": "0.5.13",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.2",
+        "@firebase/auth-compat": "0.6.7",
+        "@firebase/data-connect": "0.7.1",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.15.0",
+        "@firebase/firestore-compat": "0.4.10",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-compat": "0.4.5",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/messaging-compat": "0.2.27",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.8.4",
+        "@firebase/remote-config-compat": "0.2.25",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
+      }
+    },
     "node_modules/firebase-admin": {
       "version": "13.10.0",
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
@@ -6798,7 +7337,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -7380,6 +7918,12 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -8207,8 +8751,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -8269,8 +8812,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -9315,7 +9857,6 @@
       "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9577,7 +10118,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10909,6 +11449,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
@@ -11161,7 +11707,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -11189,7 +11734,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -11208,7 +11752,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -11218,7 +11761,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -11227,15 +11769,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11250,7 +11790,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "firebase": "^12.14.0",
     "firebase-admin": "^13.10.0",
     "lucide-react": "^0.469.0",
     "next": "15.3.8",

--- a/src/app/api/auth/firebase-token/route.ts
+++ b/src/app/api/auth/firebase-token/route.ts
@@ -1,5 +1,5 @@
-import { getAuth } from 'firebase-admin/auth';
 import { getToken } from 'next-auth/jwt';
+import { getAuth } from 'firebase-admin/auth';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { authSecret } from '@/lib/auth-secret';

--- a/src/app/api/auth/firebase-token/route.ts
+++ b/src/app/api/auth/firebase-token/route.ts
@@ -1,0 +1,24 @@
+import { getAuth } from 'firebase-admin/auth';
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authSecret } from '@/lib/auth-secret';
+
+export async function GET(request: NextRequest) {
+  const token = await getToken({ req: request, secret: authSecret });
+  const userId = token?.sub ?? null;
+
+  if (!userId) {
+    return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+  }
+
+  try {
+    const firebaseToken = await getAuth().createCustomToken(userId);
+
+    return NextResponse.json({ token: firebaseToken }, { status: 200 });
+  } catch (error) {
+    console.error('Failed to create Firebase custom token:', error);
+
+    return NextResponse.json({ error: 'Erro ao gerar token' }, { status: 500 });
+  }
+}

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -57,7 +57,7 @@ function timestampToIso(value: unknown): string {
 
 function CategoriesContextProvider({ children }: CategoryProviderProps) {
   const { status: sessionStatus } = useSession();
-  const { isReady } = useFirebaseAuth();
+  const { isReady, isError } = useFirebaseAuth();
 
   const [categories, setCategories] = useState<CategoryProps[]>([]);
   const [errorCategories, setErrorCategories] = useState<string | null>(null);
@@ -264,6 +264,13 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
       filterCategory(filteredCategory._id);
     }
   }, [categories, filterCategory, filteredCategory]);
+
+  useEffect(() => {
+    if (isError) {
+      setIsLoadingCategories(false);
+      setErrorCategories('Falha ao conectar em tempo real');
+    }
+  }, [isError]);
 
   useEffect(() => {
     if (

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -6,8 +6,8 @@ import { query, where, Timestamp, collection, onSnapshot } from 'firebase/firest
 import React, { useRef, useState, useEffect, useContext, useCallback, createContext } from 'react';
 
 import { AuthStatusEnum } from '@/types/enums';
-import { getClientAuth, getClientDb } from '@/lib/firebase-client';
 import { useFirebaseAuth } from '@/hooks/useFirebaseAuth';
+import { getClientDb, getClientAuth } from '@/lib/firebase-client';
 import { ProductProps, CategoryProps } from '@/types/interfaces';
 
 interface RawCategory {

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -6,7 +6,7 @@ import { query, where, Timestamp, collection, onSnapshot } from 'firebase/firest
 import React, { useRef, useState, useEffect, useContext, useCallback, createContext } from 'react';
 
 import { AuthStatusEnum } from '@/types/enums';
-import { db, auth } from '@/lib/firebase-client';
+import { getClientAuth, getClientDb } from '@/lib/firebase-client';
 import { useFirebaseAuth } from '@/hooks/useFirebaseAuth';
 import { ProductProps, CategoryProps } from '@/types/interfaces';
 
@@ -132,18 +132,18 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
   useEffect(() => {
     if (!isReady || sessionStatus !== AuthStatusEnum.authenticated) return;
 
-    const userId = auth.currentUser?.uid;
+    const userId = getClientAuth().currentUser?.uid;
     if (!userId) return;
 
     pendingInitialSnapshots.current = 2;
 
     const categoriesQuery = query(
-      collection(db, 'categories'),
+      collection(getClientDb(), 'categories'),
       where('userId', '==', userId)
     );
 
     const productsQuery = query(
-      collection(db, 'products'),
+      collection(getClientDb(), 'products'),
       where('userId', '==', userId)
     );
 

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -2,10 +2,32 @@
 
 import { toast } from 'sonner';
 import { useSession } from 'next-auth/react';
-import React, { useState, useEffect, useContext, useCallback, useRef, createContext } from 'react';
+import { query, where, Timestamp, collection, onSnapshot } from 'firebase/firestore';
+import React, { useRef, useState, useEffect, useContext, useCallback, createContext } from 'react';
 
 import { AuthStatusEnum } from '@/types/enums';
-import { CategoryProps } from '@/types/interfaces';
+import { db, auth } from '@/lib/firebase-client';
+import { useFirebaseAuth } from '@/hooks/useFirebaseAuth';
+import { ProductProps, CategoryProps } from '@/types/interfaces';
+
+interface RawCategory {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface RawProduct {
+  id: string;
+  name: string;
+  categoryId: string;
+  price?: string;
+  quantity?: string;
+  unit?: string;
+  addToCart?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
 
 interface CategoriesContextType {
   categories: CategoryProps[];
@@ -27,8 +49,15 @@ interface CategoryProviderProps {
 
 export const CategoriesContext = createContext({} as CategoriesContextType);
 
+function timestampToIso(value: unknown): string {
+  if (value instanceof Timestamp) return value.toDate().toISOString();
+  if (value instanceof Date) return value.toISOString();
+  return new Date().toISOString();
+}
+
 function CategoriesContextProvider({ children }: CategoryProviderProps) {
   const { status: sessionStatus } = useSession();
+  const { isReady } = useFirebaseAuth();
 
   const [categories, setCategories] = useState<CategoryProps[]>([]);
   const [errorCategories, setErrorCategories] = useState<string | null>(null);
@@ -37,12 +66,149 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
   const [filteredCategory, setFilteredCategory] = useState<CategoryProps | undefined>(undefined);
 
   const localMutationCount = useRef(0);
+  const latestCategoriesRef = useRef<RawCategory[]>([]);
+  const latestProductsRef = useRef<RawProduct[]>([]);
+  const pendingInitialSnapshots = useRef(2);
 
   const markLocalMutation = useCallback((count = 1) => {
     localMutationCount.current += count;
   }, []);
 
+  const buildCategoriesFromRefs = useCallback((): CategoryProps[] => {
+    const cats = latestCategoriesRef.current;
+    const prods = latestProductsRef.current;
+
+    return cats
+      .map((cat): CategoryProps => {
+        const catRef: CategoryProps = {
+          _id: cat.id,
+          name: cat.name,
+          createdAt: cat.createdAt,
+          updatedAt: cat.updatedAt,
+        };
+
+        const products: ProductProps[] = prods
+          .filter((p) => p.categoryId === cat.id)
+          .map((p) => ({
+            _id: p.id,
+            name: p.name,
+            price: p.price,
+            quantity: p.quantity,
+            unit: p.unit,
+            categoryId: p.categoryId,
+            addToCart: Boolean(p.addToCart),
+            createdAt: p.createdAt,
+            updatedAt: p.updatedAt,
+            category: catRef,
+          }))
+          .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'pt-BR'));
+
+        return { ...catRef, products };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name, 'pt-BR', { sensitivity: 'base' }));
+  }, []);
+
+  const handleSnapshotUpdate = useCallback(
+    (isInitial: boolean) => {
+      const rebuilt = buildCategoriesFromRefs();
+      setCategories(rebuilt);
+
+      if (pendingInitialSnapshots.current === 0) {
+        setIsLoadingCategories(false);
+      }
+
+      if (isInitial) return;
+
+      if (localMutationCount.current > 0) {
+        localMutationCount.current -= 1;
+        return;
+      }
+
+      toast('Lista atualizada');
+    },
+    [buildCategoriesFromRefs]
+  );
+
+  useEffect(() => {
+    if (!isReady || sessionStatus !== AuthStatusEnum.authenticated) return;
+
+    const userId = auth.currentUser?.uid;
+    if (!userId) return;
+
+    pendingInitialSnapshots.current = 2;
+
+    const categoriesQuery = query(
+      collection(db, 'categories'),
+      where('userId', '==', userId)
+    );
+
+    const productsQuery = query(
+      collection(db, 'products'),
+      where('userId', '==', userId)
+    );
+
+    const unsubCategories = onSnapshot(
+      categoriesQuery,
+      (snapshot) => {
+        const isInitial = pendingInitialSnapshots.current > 0;
+        if (isInitial) pendingInitialSnapshots.current -= 1;
+
+        latestCategoriesRef.current = snapshot.docs.map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            name: data.name as string,
+            createdAt: timestampToIso(data.createdAt),
+            updatedAt: timestampToIso(data.updatedAt),
+          };
+        });
+
+        handleSnapshotUpdate(isInitial);
+      },
+      (error) => {
+        console.error('Categories listener error:', error);
+        setErrorCategories(error.message);
+      }
+    );
+
+    const unsubProducts = onSnapshot(
+      productsQuery,
+      (snapshot) => {
+        const isInitial = pendingInitialSnapshots.current > 0;
+        if (isInitial) pendingInitialSnapshots.current -= 1;
+
+        latestProductsRef.current = snapshot.docs.map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            name: data.name as string,
+            categoryId: data.categoryId as string,
+            price: data.price as string | undefined,
+            quantity: data.quantity as string | undefined,
+            unit: data.unit as string | undefined,
+            addToCart: data.addToCart as boolean | undefined,
+            createdAt: timestampToIso(data.createdAt),
+            updatedAt: timestampToIso(data.updatedAt),
+          };
+        });
+
+        handleSnapshotUpdate(isInitial);
+      },
+      (error) => {
+        console.error('Products listener error:', error);
+        setErrorCategories(error.message);
+      }
+    );
+
+    return () => {
+      unsubCategories();
+      unsubProducts();
+    };
+  }, [isReady, sessionStatus, handleSnapshotUpdate]);
+
   const addCategory = async (category: CategoryProps) => {
+    markLocalMutation();
+
     const response = await fetch('/api/categories', {
       method: 'POST',
       body: JSON.stringify(category),
@@ -50,71 +216,48 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
     });
 
     if (!response.ok) {
+      localMutationCount.current -= 1;
       toast('Erro ao criar categoria');
       throw new Error('Failed to create category');
     }
 
-    const { data } = await response.json();
-
-    setCategories(prev =>
-      [...prev, data].sort((categoryA, categoryB) =>
-        categoryA.name.localeCompare(categoryB.name, 'pt-BR', { sensitivity: 'base' })
-      )
-    );
     toast('Categoria criada com sucesso');
   };
 
   const removeCategory = async (id: string) => {
+    const productCount = categories.find((c) => c._id === id)?.products?.length ?? 0;
+    markLocalMutation(1 + productCount);
+
     const response = await fetch(`/api/categories?id=${id}`, {
       method: 'DELETE',
     });
 
     if (!response.ok) {
+      localMutationCount.current -= (1 + productCount);
       toast('Erro ao remover categoria');
       return;
     }
 
-    const status = response.status;
-
-    if (status === 204) {
-      setCategories(prev => prev.filter(category => category._id !== id));
-
+    if (response.status === 204) {
       toast('Categoria removida com sucesso');
     }
-  } ;
+  };
 
   const fetchCategories = useCallback(async () => {
-    try {
-      setIsLoadingCategories(true);
-
-      const response = await fetch('/api/categories');
-
-      if (!response.ok) throw new Error('Failed to fetch products');
-
-      const data: CategoryProps[] = await response.json();
-
-      const orderCategories: CategoryProps[] = data.sort((categoryA, categoryB) =>
-        categoryA.name.localeCompare(categoryB.name, 'pt-BR', { sensitivity: 'base' })
-      );
-
-      setCategories(orderCategories);
-    } catch (err) {
-      setErrorCategories(err instanceof Error ? err.message : 'An error occurred');
-    } finally {
-      setIsLoadingCategories(false);
-    }
+    // No-op: initial load is handled by onSnapshot
   }, []);
 
-  const filterCategory = useCallback((categoryId: string) => {
-    if (!categoryId || categoryId === 'all') {
-      setFilteredCategory(undefined);
-      return;
-    }
-
-    const filteredCategory = categories.find(category => category?._id === categoryId);
-
-    setFilteredCategory(filteredCategory);
-  }, [categories]);
+  const filterCategory = useCallback(
+    (categoryId: string) => {
+      if (!categoryId || categoryId === 'all') {
+        setFilteredCategory(undefined);
+        return;
+      }
+      const found = categories.find((category) => category?._id === categoryId);
+      setFilteredCategory(found);
+    },
+    [categories]
+  );
 
   useEffect(() => {
     if (filteredCategory) {
@@ -123,26 +266,24 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
   }, [categories, filterCategory, filteredCategory]);
 
   useEffect(() => {
-    if (sessionStatus === AuthStatusEnum.loading || sessionStatus === AuthStatusEnum.unauthenticated) {
+    if (
+      sessionStatus === AuthStatusEnum.loading ||
+      sessionStatus === AuthStatusEnum.unauthenticated
+    ) {
       return;
     }
 
-    if (categories.length === 0) {
-      fetchCategories();
-    }
-
     if (selectedCategoryId && categories.length > 0) {
-      const category = categories.find(category => category._id === selectedCategoryId);
+      const category = categories.find((c) => c._id === selectedCategoryId);
 
       if (!category) {
         toast('Categoria não encontrada');
-
         return;
       }
 
       setFilteredCategory(category);
     }
-  }, [selectedCategoryId, categories, fetchCategories, filterCategory, sessionStatus]);
+  }, [selectedCategoryId, categories, sessionStatus]);
 
   return (
     <CategoriesContext.Provider

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -7,8 +7,8 @@ import React, { useRef, useState, useEffect, useContext, useCallback, createCont
 
 import { AuthStatusEnum } from '@/types/enums';
 import { useFirebaseAuth } from '@/hooks/useFirebaseAuth';
-import { getClientDb, getClientAuth } from '@/lib/firebase-client';
 import { ProductProps, CategoryProps } from '@/types/interfaces';
+import { getClientDb, getClientAuth } from '@/lib/firebase-client';
 
 interface RawCategory {
   id: string;

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -2,7 +2,7 @@
 
 import { toast } from 'sonner';
 import { useSession } from 'next-auth/react';
-import React, { useState, useEffect, useContext, useCallback, createContext } from 'react';
+import React, { useState, useEffect, useContext, useCallback, useRef, createContext } from 'react';
 
 import { AuthStatusEnum } from '@/types/enums';
 import { CategoryProps } from '@/types/interfaces';
@@ -18,6 +18,7 @@ interface CategoriesContextType {
   setSelectedCategoryId: (categoryId: string) => void;
   setCategories: React.Dispatch<React.SetStateAction<CategoryProps[]>>;
   addCategory: (category: CategoryProps) => Promise<void>;
+  markLocalMutation: (count?: number) => void;
 }
 
 interface CategoryProviderProps {
@@ -34,6 +35,12 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
   const [isLoadingCategories, setIsLoadingCategories] = useState<boolean>(true);
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | undefined>(undefined);
   const [filteredCategory, setFilteredCategory] = useState<CategoryProps | undefined>(undefined);
+
+  const localMutationCount = useRef(0);
+
+  const markLocalMutation = useCallback((count = 1) => {
+    localMutationCount.current += count;
+  }, []);
 
   const addCategory = async (category: CategoryProps) => {
     const response = await fetch('/api/categories', {
@@ -150,6 +157,7 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
         selectedCategoryId,
         isLoadingCategories,
         setSelectedCategoryId,
+        markLocalMutation,
       }}
     >
       {children}

--- a/src/context/ProductContext.tsx
+++ b/src/context/ProductContext.tsx
@@ -40,7 +40,7 @@ interface ProductsProviderProps {
 export const ProductsContext = createContext({} as ProductsContextType);
 
 function ProductsContextProvider({ children }: ProductsProviderProps) {
-  const { categories, setCategories, selectedCategoryId } = useCategories();
+  const { categories, setCategories, selectedCategoryId, markLocalMutation } = useCategories();
 
   const [error, setError] = useState<string | null>(null);
   const [hasAnyProduct, setHasAnyProduct] = useState(false);
@@ -97,6 +97,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
       setIsProductLoading({ productId: product._id || null, isLoading: true });
 
       if (product._id) {
+        markLocalMutation();
         const response = await fetch(`/api/products/${product._id}`, {
           method: 'PUT',
           body: JSON.stringify(product),
@@ -145,6 +146,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
 
         toast.success('Produto atualizado');
       } else {
+        markLocalMutation();
         const response = await fetch('/api/products', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -180,6 +182,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
   const removeProduct = async (id: string) => {
     try {
       setIsProductLoading({ productId: id, isLoading: true });
+      markLocalMutation();
 
       const response = await fetch(`/api/products/${id}`, {
         method: 'DELETE',
@@ -211,9 +214,14 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
 
   const removeAllProducts = async () => {
     try {
-      await Promise.all(categories.flatMap(category => category.products || []).map(product =>
-        fetch(`/api/products/${product._id}`, { method: 'DELETE' })
-      ));
+      const allProducts = categories.flatMap((category) => category.products || []);
+      markLocalMutation(allProducts.length);
+
+      await Promise.all(
+        allProducts.map((product) =>
+          fetch(`/api/products/${product._id}`, { method: 'DELETE' })
+        )
+      );
 
       setCategories(prev => prev.map(category => ({
         ...category,
@@ -229,6 +237,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
     if (!id) return;
 
     setIsProductLoading({ productId: id, isLoading: true });
+    markLocalMutation();
 
     try {
       const product = categories.flatMap(category => category.products || []).find(product => product._id === id);

--- a/src/context/ProductContext.tsx
+++ b/src/context/ProductContext.tsx
@@ -105,6 +105,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
         });
 
         if (!response.ok) {
+          markLocalMutation(-1);
           toast('Erro ao atualizar o produto');
 
           throw new Error('Failed to update product');
@@ -154,6 +155,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
         });
 
         if (!response.ok) {
+          markLocalMutation(-1);
           toast('Erro ao criar o produto');
 
           throw new Error('Failed to create product');
@@ -189,6 +191,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
       });
 
       if (!response.ok) {
+        markLocalMutation(-1);
         const productName = categories.flatMap(category => category.products || []).find(product => product._id === id)?.name;
 
         toast(`Erro ao remover o produto ${productName}`);
@@ -213,8 +216,9 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
   };
 
   const removeAllProducts = async () => {
+    const allProducts = categories.flatMap((category) => category.products || []);
+
     try {
-      const allProducts = categories.flatMap((category) => category.products || []);
       markLocalMutation(allProducts.length);
 
       await Promise.all(
@@ -229,6 +233,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
       })));
 
     } catch (err) {
+      markLocalMutation(-allProducts.length);
       setError(err instanceof Error ? err.message : 'An error occurred');
     }
   };
@@ -237,13 +242,13 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
     if (!id) return;
 
     setIsProductLoading({ productId: id, isLoading: true });
-    markLocalMutation();
 
     try {
       const product = categories.flatMap(category => category.products || []).find(product => product._id === id);
 
       if (!product) return;
 
+      markLocalMutation();
       const response = await fetch(`/api/products/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -251,6 +256,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
       });
 
       if (!response.ok) {
+        markLocalMutation(-1);
         toast.error('Erro ao atualizar produto no carrinho');
 
         throw new Error('Failed to update product');

--- a/src/hooks/useFirebaseAuth.ts
+++ b/src/hooks/useFirebaseAuth.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { signInWithCustomToken } from 'firebase/auth';
+import { useSession } from 'next-auth/react';
+import { useState, useEffect } from 'react';
+
+import { auth } from '@/lib/firebase-client';
+import { AuthStatusEnum } from '@/types/enums';
+
+export function useFirebaseAuth() {
+  const { status: sessionStatus } = useSession();
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    if (sessionStatus !== AuthStatusEnum.authenticated) return;
+
+    let cancelled = false;
+
+    async function authenticate() {
+      try {
+        const response = await fetch('/api/auth/firebase-token');
+
+        if (!response.ok) return;
+
+        const { token } = await response.json();
+
+        await signInWithCustomToken(auth, token);
+
+        if (!cancelled) {
+          setIsReady(true);
+        }
+      } catch (error) {
+        console.error('Firebase auth failed:', error);
+      }
+    }
+
+    authenticate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionStatus]);
+
+  return { isReady };
+}

--- a/src/hooks/useFirebaseAuth.ts
+++ b/src/hooks/useFirebaseAuth.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { signInWithCustomToken } from 'firebase/auth';
 
-import { auth } from '@/lib/firebase-client';
+import { getClientAuth } from '@/lib/firebase-client';
 import { AuthStatusEnum } from '@/types/enums';
 
 export function useFirebaseAuth() {
@@ -28,7 +28,7 @@ export function useFirebaseAuth() {
 
         const { token } = await response.json();
 
-        await signInWithCustomToken(auth, token);
+        await signInWithCustomToken(getClientAuth(), token);
 
         if (!cancelled) {
           setIsReady(true);

--- a/src/hooks/useFirebaseAuth.ts
+++ b/src/hooks/useFirebaseAuth.ts
@@ -1,8 +1,8 @@
 'use client';
 
-import { signInWithCustomToken } from 'firebase/auth';
-import { useSession } from 'next-auth/react';
 import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { signInWithCustomToken } from 'firebase/auth';
 
 import { auth } from '@/lib/firebase-client';
 import { AuthStatusEnum } from '@/types/enums';
@@ -10,6 +10,7 @@ import { AuthStatusEnum } from '@/types/enums';
 export function useFirebaseAuth() {
   const { status: sessionStatus } = useSession();
   const [isReady, setIsReady] = useState(false);
+  const [isError, setIsError] = useState(false);
 
   useEffect(() => {
     if (sessionStatus !== AuthStatusEnum.authenticated) return;
@@ -20,7 +21,10 @@ export function useFirebaseAuth() {
       try {
         const response = await fetch('/api/auth/firebase-token');
 
-        if (!response.ok) return;
+        if (!response.ok) {
+          if (!cancelled) setIsError(true);
+          return;
+        }
 
         const { token } = await response.json();
 
@@ -31,6 +35,7 @@ export function useFirebaseAuth() {
         }
       } catch (error) {
         console.error('Firebase auth failed:', error);
+        if (!cancelled) setIsError(true);
       }
     }
 
@@ -41,5 +46,5 @@ export function useFirebaseAuth() {
     };
   }, [sessionStatus]);
 
-  return { isReady };
+  return { isReady, isError };
 }

--- a/src/hooks/useFirebaseAuth.ts
+++ b/src/hooks/useFirebaseAuth.ts
@@ -4,8 +4,8 @@ import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { signInWithCustomToken } from 'firebase/auth';
 
-import { getClientAuth } from '@/lib/firebase-client';
 import { AuthStatusEnum } from '@/types/enums';
+import { getClientAuth } from '@/lib/firebase-client';
 
 export function useFirebaseAuth() {
   const { status: sessionStatus } = useSession();

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -1,6 +1,6 @@
+import { getAuth, connectAuthEmulator } from 'firebase/auth';
 import { getApp, getApps, initializeApp } from 'firebase/app';
-import { connectAuthEmulator, getAuth } from 'firebase/auth';
-import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
 
 const clientConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -8,16 +8,29 @@ const clientConfig = {
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
 };
 
-const app = getApps().length ? getApp() : initializeApp(clientConfig);
+let emulatorsConnected = false;
 
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+// Lazy initialization — avoids running initializeApp during SSR/prerendering
+function getClientApp() {
+  const app = getApps().length ? getApp() : initializeApp(clientConfig);
 
-if (process.env.NODE_ENV === 'development') {
-  try {
-    connectFirestoreEmulator(db, 'localhost', 8080);
-    connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
-  } catch {
-    // Emulators already connected (HMR re-execution)
+  if (process.env.NODE_ENV === 'development' && !emulatorsConnected) {
+    emulatorsConnected = true;
+    try {
+      connectAuthEmulator(getAuth(app), 'http://localhost:9099', { disableWarnings: true });
+      connectFirestoreEmulator(getFirestore(app), 'localhost', 8080);
+    } catch {
+      // Emulators already connected (HMR re-execution)
+    }
   }
+
+  return app;
+}
+
+export function getClientAuth() {
+  return getAuth(getClientApp());
+}
+
+export function getClientDb() {
+  return getFirestore(getClientApp());
 }

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -1,0 +1,23 @@
+import { getApp, getApps, initializeApp } from 'firebase/app';
+import { connectAuthEmulator, getAuth } from 'firebase/auth';
+import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
+
+const clientConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+};
+
+const app = getApps().length ? getApp() : initializeApp(clientConfig);
+
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+
+if (process.env.NODE_ENV === 'development') {
+  try {
+    connectFirestoreEmulator(db, 'localhost', 8080);
+    connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
+  } catch {
+    // Emulators already connected (HMR re-execution)
+  }
+}


### PR DESCRIPTION
## Summary

- Add Firebase client SDK with `onSnapshot` listeners for real-time Firestore reads, replacing the one-time `fetchCategories()` fetch — changes from any device reflect instantly without a page reload
- Bridge NextAuth sessions to Firebase client auth via a custom token endpoint (`GET /api/auth/firebase-token`) so the browser can authenticate directly with Firestore
- Differentiate local vs. remote mutations using a `localMutationCount` ref — only remote changes trigger the \"Lista atualizada\" toast (Sonner), while changes made by the current device are silent
- Add Firestore security rules that allow client-side reads only by the document's owner, with all writes blocked from the client (Admin SDK on the server continues to work)

## Architecture

Writes continue exclusively via API routes with Admin SDK (unchanged). Real-time reads are handled client-side:

```
Login (NextAuth)
  → GET /api/auth/firebase-token  (custom token via Admin SDK)
  → signInWithCustomToken(auth, token)
  → onSnapshot(categories + products filtered by userId)
  → state update + toast("Lista atualizada")  ← remote changes only
```

## New files

- `src/lib/firebase-client.ts` — Firebase client SDK singleton (with emulator support)
- `src/app/api/auth/firebase-token/route.ts` — protected endpoint generating custom tokens
- `src/hooks/useFirebaseAuth.ts` — client auth hook (fetches token, signs in, exposes `isReady`/`isError`)
- `firestore.rules` — security rules for client-side reads
- `.env.example` — template with `NEXT_PUBLIC_FIREBASE_*` and `FIREBASE_AUTH_EMULATOR_HOST`
- `docs/superpowers/specs/2026-06-08-realtime-sync-design.md` — design spec
- `docs/superpowers/plans/2026-06-08-realtime-sync.md` — implementation plan

## Modified files

- `src/context/CategoryContext.tsx` — replaced `fetchCategories` with dual `onSnapshot` listeners; added `markLocalMutation` / mutation counter logic
- `src/context/ProductContext.tsx` — calls `markLocalMutation()` before each mutation and rolls back on failure
- `firebase.json` — added auth emulator (port 9099) and firestore rules reference

## Test plan

- [ ] Add `NEXT_PUBLIC_FIREBASE_API_KEY`, `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`, `NEXT_PUBLIC_FIREBASE_PROJECT_ID` to Vercel environment variables
- [ ] Deploy Firestore security rules: `firebase deploy --only firestore:rules`
- [ ] Open the app in two browsers simultaneously and mutate a list in one — confirm the other updates automatically with the toast
- [ ] Confirm that mutations made in the same browser do NOT show the toast
- [ ] Confirm the app loads normally when Firebase auth fails (error path: `isLoadingCategories` resolves, error message shown)
- [ ] Run `tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)