### PR TITLE
feat(shared-lists): allow category owners to share lists via a link

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,16 +5,18 @@ service cloud.firestore {
     match /categories/{categoryId} {
       allow read: if request.auth != null
                   && (request.auth.uid == resource.data.userId
-                      || request.auth.uid in resource.data.sharedWith);
+                      || ('sharedWith' in resource.data
+                          && request.auth.uid in resource.data.sharedWith));
       allow write: if false;
     }
 
     match /products/{productId} {
       allow read: if request.auth != null
                   && (request.auth.uid == resource.data.userId
-                      || request.auth.uid in
-                         get(/databases/$(database)/documents/categories/$(resource.data.categoryId))
-                         .data.sharedWith);
+                      || ('sharedWith' in get(/databases/$(database)/documents/categories/$(resource.data.categoryId)).data
+                          && request.auth.uid in
+                             get(/databases/$(database)/documents/categories/$(resource.data.categoryId))
+                             .data.sharedWith));
       allow write: if false;
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,13 +4,17 @@ service cloud.firestore {
 
     match /categories/{categoryId} {
       allow read: if request.auth != null
-                  && request.auth.uid == resource.data.userId;
+                  && (request.auth.uid == resource.data.userId
+                      || request.auth.uid in resource.data.sharedWith);
       allow write: if false;
     }
 
     match /products/{productId} {
       allow read: if request.auth != null
-                  && request.auth.uid == resource.data.userId;
+                  && (request.auth.uid == resource.data.userId
+                      || request.auth.uid in
+                         get(/databases/$(database)/documents/categories/$(resource.data.categoryId))
+                         .data.sharedWith);
       allow write: if false;
     }
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -60,7 +60,8 @@ function LoginErrorBanner() {
 export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get('callbackUrl') ?? '/';
+  const rawCallback = searchParams.get('callbackUrl') ?? '/';
+  const callbackUrl = rawCallback.startsWith('/') ? rawCallback : '/';
   const [isLoading, setIsLoading] = useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
   const [currentEmail, setCurrentEmail] = useState('');

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -58,6 +58,14 @@ function LoginErrorBanner() {
 }
 
 export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginPageContent />
+    </Suspense>
+  );
+}
+
+function LoginPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const rawCallback = searchParams.get('callbackUrl') ?? '/';

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -59,6 +59,8 @@ function LoginErrorBanner() {
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get('callbackUrl') ?? '/';
   const [isLoading, setIsLoading] = useState(false);
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
   const [currentEmail, setCurrentEmail] = useState('');
@@ -103,7 +105,7 @@ export default function LoginPage() {
   const handleGoogleSignIn = async () => {
     try {
       setIsGoogleLoading(true);
-      await signIn('google', { callbackUrl: '/' });
+      await signIn('google', { callbackUrl });
     } catch {
       toast.error('Não foi possível entrar com Google. Tente novamente ou use seu email.');
       setIsGoogleLoading(false);
@@ -179,7 +181,7 @@ export default function LoginPage() {
         throw new Error('Código inválido');
       }
 
-      router.push('/');
+      router.push(callbackUrl);
     } catch (error) {
       let errorMessage = 'Erro ao verificar código. Tente novamente.';
       if (error instanceof Error) {

--- a/src/app/api/categories/[id]/share/route.ts
+++ b/src/app/api/categories/[id]/share/route.ts
@@ -1,0 +1,36 @@
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authSecret } from '@/lib/auth-secret';
+import { generateShareToken } from '@/lib/firestore-domain';
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  try {
+    const token = await getToken({ req: request, secret: authSecret });
+    const userId = token?.sub ?? null;
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+    }
+
+    const { id: categoryId } = await context.params;
+
+    const shareToken = await generateShareToken(userId, categoryId);
+
+    if (!shareToken) {
+      return NextResponse.json({ error: 'Categoria não encontrada' }, { status: 404 });
+    }
+
+    const origin = request.nextUrl.origin;
+    const shareUrl = `${origin}/share/${shareToken}`;
+
+    return NextResponse.json({ shareUrl }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Erro ao gerar link' }, { status: 500 });
+  }
+}

--- a/src/app/api/share/[token]/route.ts
+++ b/src/app/api/share/[token]/route.ts
@@ -1,0 +1,33 @@
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authSecret } from '@/lib/auth-secret';
+import { joinSharedList } from '@/lib/firestore-domain';
+
+type RouteContext = {
+  params: Promise<{ token: string }>;
+};
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const jwtToken = await getToken({ req: request, secret: authSecret });
+    const userId = jwtToken?.sub ?? null;
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+    }
+
+    const { token } = await context.params;
+
+    const result = await joinSharedList(token, userId);
+
+    if (!result) {
+      return NextResponse.json({ error: 'Link inválido' }, { status: 404 });
+    }
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Erro ao entrar na lista' }, { status: 500 });
+  }
+}

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+
+import { Header } from '@/components/header';
+import { LoadingSpinner } from '@/components/loading-spinner';
+
+interface SharePageProps {
+  params: Promise<{ token: string }>;
+}
+
+export default function SharePage({ params }: SharePageProps) {
+  const router = useRouter();
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    async function join() {
+      const { token } = await params;
+
+      try {
+        const response = await fetch(`/api/share/${token}`, { method: 'POST' });
+
+        if (!response.ok) {
+          setError(true);
+          return;
+        }
+
+        const { categoryName } = await response.json();
+        toast.success(`Você foi adicionado à lista ${categoryName}`);
+        router.push('/');
+      } catch {
+        setError(true);
+      }
+    }
+
+    join();
+  }, [params, router]);
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4">
+        <Header />
+        <p className="mt-4 text-sm text-destructive">Link inválido ou expirado.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4">
+      <Header />
+      <div className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
+        <LoadingSpinner />
+        <span>Entrando na lista...</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/category-card.tsx
+++ b/src/components/category-card.tsx
@@ -90,15 +90,19 @@ export function CategoryCard() {
             )}
           </div>
 
-          <div className="h-px w-full bg-[var(--color-hairline)]" />
+          {!category.isShared && (
+            <>
+              <div className="h-px w-full bg-[var(--color-hairline)]" />
 
-          <button
-            onClick={() => handleRemoveClick(category)}
-            aria-label="Remover categoria"
-            className="flex h-10 w-full items-center justify-center bg-[var(--color-surface-soft)] transition-colors hover:bg-[var(--color-surface-card)]"
-          >
-            <Trash2 className="h-4 w-4 text-[var(--color-error)]" />
-          </button>
+              <button
+                onClick={() => handleRemoveClick(category)}
+                aria-label="Remover categoria"
+                className="flex h-10 w-full items-center justify-center bg-[var(--color-surface-soft)] transition-colors hover:bg-[var(--color-surface-card)]"
+              >
+                <Trash2 className="h-4 w-4 text-[var(--color-error)]" />
+              </button>
+            </>
+          )}
         </div>
       ));
     }

--- a/src/components/category-select.tsx
+++ b/src/components/category-select.tsx
@@ -40,7 +40,7 @@ export function CategorySelect() {
             <span className="flex items-center gap-1.5">
               {category.name}
               {category.isShared && (
-                <Users className="h-3 w-3 text-muted-foreground shrink-0" />
+                <Users aria-hidden="true" className="h-3 w-3 text-muted-foreground shrink-0" />
               )}
             </span>
           </SelectItem>

--- a/src/components/category-select.tsx
+++ b/src/components/category-select.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ChevronDown } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { Users, ChevronDown } from 'lucide-react';
 
 import { useCategories } from '@/context';
 import { Select, SelectItem, SelectContent, SelectTrigger } from '@/components/ui/select';
@@ -37,7 +37,12 @@ export function CategorySelect() {
       <SelectContent>
         {categories.map((category) => (
           <SelectItem key={category._id} value={category._id}>
-            {category.name}
+            <span className="flex items-center gap-1.5">
+              {category.name}
+              {category.isShared && (
+                <Users className="h-3 w-3 text-muted-foreground shrink-0" />
+              )}
+            </span>
           </SelectItem>
         ))}
       </SelectContent>

--- a/src/components/product-list-header.tsx
+++ b/src/components/product-list-header.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { toast } from 'sonner';
+import { Share2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useProducts, useCategories } from '@/context';
 import { StatusEnum, PrettyStatusEnum } from '@/types/enums';
@@ -16,7 +20,28 @@ import { CategorySelect } from './category-select';
 
 export function ProductListHeader() {
   const { filter, setFilter } = useProducts();
-  const { isLoadingCategories } = useCategories();
+  const { isLoadingCategories, filteredCategory } = useCategories();
+
+  const isOwner = filteredCategory != null && !filteredCategory.isShared;
+
+  async function handleShare() {
+    if (!filteredCategory?._id) return;
+
+    try {
+      const response = await fetch(`/api/categories/${filteredCategory._id}/share`);
+
+      if (!response.ok) {
+        toast.error('Não foi possível gerar o link');
+        return;
+      }
+
+      const { shareUrl } = await response.json();
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success('Link copiado!');
+    } catch {
+      toast.error('Não foi possível copiar o link');
+    }
+  }
 
   return (
     <header className="flex items-center justify-between gap-4 w-full">
@@ -43,13 +68,20 @@ export function ProductListHeader() {
             </Select>
           </div>
 
-          <div className="flex flex-col gap-1" >
+          <div className="flex flex-col gap-1">
             <Label className="font-bold text-sm">Filtro de Categorias</Label>
 
             <CategorySelect />
           </div>
         </div>
       )}
+
+      {isOwner && (
+        <Button variant="outline" size="sm" onClick={handleShare} className="shrink-0">
+          <Share2 className="h-4 w-4 mr-1" />
+          Compartilhar
+        </Button>
+      )}
     </header>
   );
-};
+}

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -69,25 +69,41 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
   const latestCategoriesRef = useRef<RawCategory[]>([]);
   const latestProductsRef = useRef<RawProduct[]>([]);
   const pendingInitialSnapshots = useRef(2);
+  const latestSharedCategoriesRef = useRef<RawCategory[]>([]);
+  const latestSharedProductsRef = useRef<RawProduct[]>([]);
 
   const markLocalMutation = useCallback((count = 1) => {
     localMutationCount.current += count;
   }, []);
 
   const buildCategoriesFromRefs = useCallback((): CategoryProps[] => {
-    const cats = latestCategoriesRef.current;
-    const prods = latestProductsRef.current;
+    const ownedCatIds = new Set(latestCategoriesRef.current.map((c) => c.id));
 
-    return cats
+    const allRawCats = [
+      ...latestCategoriesRef.current.map((c) => ({ ...c, isShared: false as const })),
+      ...latestSharedCategoriesRef.current
+        .filter((sc) => !ownedCatIds.has(sc.id))
+        .map((c) => ({ ...c, isShared: true as const })),
+    ];
+
+    const ownedProdIds = new Set(latestProductsRef.current.map((p) => p.id));
+
+    const allRawProds = [
+      ...latestProductsRef.current,
+      ...latestSharedProductsRef.current.filter((sp) => !ownedProdIds.has(sp.id)),
+    ];
+
+    return allRawCats
       .map((cat): CategoryProps => {
         const catRef: CategoryProps = {
           _id: cat.id,
           name: cat.name,
           createdAt: cat.createdAt,
           updatedAt: cat.updatedAt,
+          isShared: cat.isShared,
         };
 
-        const products: ProductProps[] = prods
+        const products: ProductProps[] = allRawProds
           .filter((p) => p.categoryId === cat.id)
           .map((p) => ({
             _id: p.id,
@@ -137,18 +153,11 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
 
     pendingInitialSnapshots.current = 2;
 
-    const categoriesQuery = query(
-      collection(getClientDb(), 'categories'),
-      where('userId', '==', userId)
-    );
-
-    const productsQuery = query(
-      collection(getClientDb(), 'products'),
-      where('userId', '==', userId)
-    );
+    const unsubscribers: (() => void)[] = [];
+    let sharedProductsUnsub: (() => void) | null = null;
 
     const unsubCategories = onSnapshot(
-      categoriesQuery,
+      query(collection(getClientDb(), 'categories'), where('userId', '==', userId)),
       (snapshot) => {
         const isInitial = pendingInitialSnapshots.current > 0;
         if (isInitial) pendingInitialSnapshots.current -= 1;
@@ -170,9 +179,10 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
         setErrorCategories(error.message);
       }
     );
+    unsubscribers.push(unsubCategories);
 
     const unsubProducts = onSnapshot(
-      productsQuery,
+      query(collection(getClientDb(), 'products'), where('userId', '==', userId)),
       (snapshot) => {
         const isInitial = pendingInitialSnapshots.current > 0;
         if (isInitial) pendingInitialSnapshots.current -= 1;
@@ -199,10 +209,78 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
         setErrorCategories(error.message);
       }
     );
+    unsubscribers.push(unsubProducts);
+
+    const unsubSharedCategories = onSnapshot(
+      query(
+        collection(getClientDb(), 'categories'),
+        where('sharedWith', 'array-contains', userId)
+      ),
+      (snapshot) => {
+        latestSharedCategoriesRef.current = snapshot.docs.map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            name: data.name as string,
+            createdAt: timestampToIso(data.createdAt),
+            updatedAt: timestampToIso(data.updatedAt),
+          };
+        });
+
+        handleSnapshotUpdate(true);
+
+        if (sharedProductsUnsub) {
+          sharedProductsUnsub();
+          sharedProductsUnsub = null;
+        }
+
+        const sharedCategoryIds = snapshot.docs.map((d) => d.id);
+
+        if (sharedCategoryIds.length === 0) {
+          latestSharedProductsRef.current = [];
+          return;
+        }
+
+        let isFirstFire = true;
+
+        sharedProductsUnsub = onSnapshot(
+          query(
+            collection(getClientDb(), 'products'),
+            where('categoryId', 'in', sharedCategoryIds)
+          ),
+          (prodSnapshot) => {
+            latestSharedProductsRef.current = prodSnapshot.docs.map((doc) => {
+              const data = doc.data();
+              return {
+                id: doc.id,
+                name: data.name as string,
+                categoryId: data.categoryId as string,
+                price: data.price as string | undefined,
+                quantity: data.quantity as string | undefined,
+                unit: data.unit as string | undefined,
+                addToCart: data.addToCart as boolean | undefined,
+                createdAt: timestampToIso(data.createdAt),
+                updatedAt: timestampToIso(data.updatedAt),
+              };
+            });
+
+            handleSnapshotUpdate(isFirstFire);
+            isFirstFire = false;
+          },
+          (error) => {
+            console.error('Shared products listener error:', error);
+          }
+        );
+      },
+      (error) => {
+        console.error('Shared categories listener error:', error);
+      }
+    );
+    unsubscribers.push(unsubSharedCategories);
 
     return () => {
-      unsubCategories();
-      unsubProducts();
+      unsubscribers.forEach((unsub) => unsub());
+      if (sharedProductsUnsub) sharedProductsUnsub();
     };
   }, [isReady, sessionStatus, handleSnapshotUpdate]);
 

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -227,18 +227,24 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
           };
         });
 
-        handleSnapshotUpdate(true);
-
         if (sharedProductsUnsub) {
           sharedProductsUnsub();
           sharedProductsUnsub = null;
         }
+        latestSharedProductsRef.current = [];
+
+        handleSnapshotUpdate(true);
 
         const sharedCategoryIds = snapshot.docs.map((d) => d.id);
 
         if (sharedCategoryIds.length === 0) {
-          latestSharedProductsRef.current = [];
           return;
+        }
+
+        const FIRESTORE_IN_LIMIT = 30;
+        const idsForQuery = sharedCategoryIds.slice(0, FIRESTORE_IN_LIMIT);
+        if (sharedCategoryIds.length > FIRESTORE_IN_LIMIT) {
+          console.warn(`User has ${sharedCategoryIds.length} shared categories; only first ${FIRESTORE_IN_LIMIT} synced.`);
         }
 
         let isFirstFire = true;
@@ -246,7 +252,7 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
         sharedProductsUnsub = onSnapshot(
           query(
             collection(getClientDb(), 'products'),
-            where('categoryId', 'in', sharedCategoryIds)
+            where('categoryId', 'in', idsForQuery)
           ),
           (prodSnapshot) => {
             latestSharedProductsRef.current = prodSnapshot.docs.map((doc) => {

--- a/src/context/ProductContext.tsx
+++ b/src/context/ProductContext.tsx
@@ -216,7 +216,9 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
   };
 
   const removeAllProducts = async () => {
-    const allProducts = categories.flatMap((category) => category.products || []);
+    const allProducts = categories
+      .filter((category) => !category.isShared)
+      .flatMap((category) => category.products || []);
 
     try {
       markLocalMutation(allProducts.length);

--- a/src/lib/firestore-domain.ts
+++ b/src/lib/firestore-domain.ts
@@ -300,3 +300,44 @@ export async function deleteProduct(userId: string, productId: string) {
 
   return true;
 }
+
+export async function generateShareToken(userId: string, categoryId: string): Promise<string | null> {
+  const categoryDoc = await categoriesCollection.doc(categoryId).get();
+
+  if (!categoryDoc.exists || categoryDoc.data()?.userId !== userId) {
+    return null;
+  }
+
+  const existing = categoryDoc.data()?.shareToken as string | undefined;
+
+  if (existing) return existing;
+
+  const token = crypto.randomUUID();
+
+  await categoriesCollection.doc(categoryId).update({ shareToken: token });
+
+  return token;
+}
+
+export async function joinSharedList(
+  token: string,
+  requestingUserId: string
+): Promise<{ categoryId: string; categoryName: string } | null> {
+  const snapshot = await categoriesCollection
+    .where('shareToken', '==', token)
+    .limit(1)
+    .get();
+
+  if (snapshot.empty) return null;
+
+  const categoryDoc = snapshot.docs[0];
+
+  await categoriesCollection
+    .doc(categoryDoc.id)
+    .update({ sharedWith: FieldValue.arrayUnion(requestingUserId) });
+
+  return {
+    categoryId: categoryDoc.id,
+    categoryName: categoryDoc.data().name as string,
+  };
+}

--- a/src/lib/firestore-domain.ts
+++ b/src/lib/firestore-domain.ts
@@ -73,6 +73,7 @@ async function getOwnedCategory(categoryId: string, userId: string) {
   return categoryFromDoc(categoryDoc);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function getOwnedProductDoc(productId: string, userId: string) {
   const productDoc = await productsCollection.doc(productId).get();
 
@@ -109,7 +110,6 @@ async function getAccessibleCategory(
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function getAccessibleProductDoc(productId: string, userId: string) {
   const productDoc = await productsCollection.doc(productId).get();
 
@@ -158,14 +158,14 @@ export async function getCategoriesWithProducts(userId: string) {
 }
 
 export async function getCategoryWithProducts(userId: string, categoryId: string) {
-  const category = await getOwnedCategory(categoryId, userId);
+  const result = await getAccessibleCategory(categoryId, userId);
 
-  if (!category) {
-    return null;
-  }
+  if (!result) return null;
+
+  const { category, ownerUserId } = result;
 
   const productsSnapshot = await productsCollection
-    .where('userId', '==', userId)
+    .where('userId', '==', ownerUserId)
     .where('categoryId', '==', categoryId)
     .get();
 
@@ -227,11 +227,11 @@ export async function getProducts(userId: string) {
 }
 
 export async function createProduct(userId: string, product: ProductWrite) {
-  const category = await getOwnedCategory(product.categoryId, userId);
+  const result = await getAccessibleCategory(product.categoryId, userId);
 
-  if (!category) {
-    return null;
-  }
+  if (!result) return null;
+
+  const { category, ownerUserId } = result;
 
   const productRef = productsCollection.doc();
 
@@ -241,7 +241,7 @@ export async function createProduct(userId: string, product: ProductWrite) {
     quantity: product.quantity ?? null,
     unit: product.unit ?? null,
     categoryId: product.categoryId,
-    userId,
+    userId: ownerUserId,
     addToCart: Boolean(product.addToCart),
     createdAt: FieldValue.serverTimestamp(),
     updatedAt: FieldValue.serverTimestamp(),
@@ -253,33 +253,28 @@ export async function createProduct(userId: string, product: ProductWrite) {
 }
 
 export async function getProduct(userId: string, productId: string) {
-  const productDoc = await getOwnedProductDoc(productId, userId);
+  const productDoc = await getAccessibleProductDoc(productId, userId);
 
-  if (!productDoc) {
-    return null;
-  }
+  if (!productDoc) return null;
 
-  const category = await getOwnedCategory(productDoc.data()?.categoryId, userId);
+  const data = productDoc.data()!;
+  const result = await getAccessibleCategory(data.categoryId as string, userId);
 
-  if (!category) {
-    return null;
-  }
+  if (!result) return null;
 
-  return productFromDoc(productDoc, category);
+  return productFromDoc(productDoc, result.category);
 }
 
 export async function updateProduct(userId: string, productId: string, product: ProductWrite) {
-  const productDoc = await getOwnedProductDoc(productId, userId);
+  const productDoc = await getAccessibleProductDoc(productId, userId);
 
-  if (!productDoc) {
-    return null;
-  }
+  if (!productDoc) return null;
 
-  const category = await getOwnedCategory(product.categoryId, userId);
+  const result = await getAccessibleCategory(product.categoryId, userId);
 
-  if (!category) {
-    return null;
-  }
+  if (!result) return null;
+
+  const { category } = result;
 
   await productsCollection.doc(productId).update({
     name: product.name,
@@ -297,11 +292,9 @@ export async function updateProduct(userId: string, productId: string, product: 
 }
 
 export async function deleteProduct(userId: string, productId: string) {
-  const productDoc = await getOwnedProductDoc(productId, userId);
+  const productDoc = await getAccessibleProductDoc(productId, userId);
 
-  if (!productDoc) {
-    return false;
-  }
+  if (!productDoc) return false;
 
   await productDoc.ref.delete();
 

--- a/src/lib/firestore-domain.ts
+++ b/src/lib/firestore-domain.ts
@@ -332,9 +332,11 @@ export async function joinSharedList(
 
   const categoryDoc = snapshot.docs[0];
 
-  await categoriesCollection
-    .doc(categoryDoc.id)
-    .update({ sharedWith: FieldValue.arrayUnion(requestingUserId) });
+  if (categoryDoc.data().userId !== requestingUserId) {
+    await categoriesCollection
+      .doc(categoryDoc.id)
+      .update({ sharedWith: FieldValue.arrayUnion(requestingUserId) });
+  }
 
   return {
     categoryId: categoryDoc.id,

--- a/src/lib/firestore-domain.ts
+++ b/src/lib/firestore-domain.ts
@@ -83,6 +83,49 @@ async function getOwnedProductDoc(productId: string, userId: string) {
   return productDoc;
 }
 
+interface AccessibleCategoryResult {
+  category: CategoryProps;
+  ownerUserId: string;
+}
+
+async function getAccessibleCategory(
+  categoryId: string,
+  userId: string
+): Promise<AccessibleCategoryResult | null> {
+  const categoryDoc = await categoriesCollection.doc(categoryId).get();
+
+  if (!categoryDoc.exists) return null;
+
+  const data = categoryDoc.data()!;
+  const isOwner = data.userId === userId;
+  const isSharedWith =
+    Array.isArray(data.sharedWith) && data.sharedWith.includes(userId);
+
+  if (!isOwner && !isSharedWith) return null;
+
+  return {
+    category: categoryFromDoc(categoryDoc),
+    ownerUserId: data.userId as string,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function getAccessibleProductDoc(productId: string, userId: string) {
+  const productDoc = await productsCollection.doc(productId).get();
+
+  if (!productDoc.exists) return null;
+
+  const data = productDoc.data()!;
+
+  if (data.userId === userId) return productDoc;
+
+  const result = await getAccessibleCategory(data.categoryId as string, userId);
+
+  if (!result) return null;
+
+  return productDoc;
+}
+
 export async function getCategoriesWithProducts(userId: string) {
   let categoriesSnapshot = await categoriesCollection.where('userId', '==', userId).get();
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,6 +16,10 @@ export async function middleware(request: NextRequest) {
 
   if (!token && !isPublicRoute) {
     const url = new URL(PagesEnum.login, request.url);
+    url.searchParams.set(
+      'callbackUrl',
+      request.nextUrl.pathname + request.nextUrl.search
+    );
 
     return NextResponse.redirect(url);
   }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -4,6 +4,7 @@ export interface CategoryProps {
   createdAt: string;
   updatedAt: string;
   products?: Array<ProductProps>;
+  isShared?: boolean;
 }
 
 export interface ProductProps {


### PR DESCRIPTION
## Summary

- **Share link generation:** Category owners can generate a permanent share link (`GET /api/categories/[id]/share`) that copies to clipboard. The link encodes a `shareToken` stored on the Firestore category document.
- **Join flow:** Any authenticated user opening `/share/[token]` is automatically added to the category's `sharedWith` array and redirected to the home page. Unauthenticated users are redirected to login with `callbackUrl` preserved so they return to the share page after logging in.
- **Real-time sync:** `CategoryContext` gains two additional `onSnapshot` listeners — one for shared categories (`sharedWith array-contains me`) and a dynamic one for their products (`categoryId in [sharedCategoryIds]`). Shared categories and owned categories are merged into a single sorted list with deduplication.
- **Full edit access:** Shared users can create, update, delete products and toggle cart. Products created by shared users are stored with the category owner's `userId` to preserve the existing listener invariants.
- **UI:** Shared categories show a `Users` icon in the category selector. The share button (copy link) is visible only to category owners. The delete button in `CategoryCard` is hidden for shared categories.

## Data model changes

- `categories/{id}` gains two optional fields: `shareToken?: string` and `sharedWith?: string[]`
- `CategoryProps` gains `isShared?: boolean` (client-derived, not stored)
- Firestore security rules updated to allow `sharedWith` members to read categories and their products (all writes remain Admin SDK only)

## Security fixes included

- `callbackUrl` validated to start with `/` to prevent open redirect
- `joinSharedList` skips `arrayUnion` when requester is the category owner (prevents polluting `sharedWith` with the owner's own uid)
- `removeAllProducts` now skips shared categories to prevent data loss

## Test plan

- [ ] Owner generates share link → link copied to clipboard, `shareToken` written to Firestore
- [ ] Shared user opens link while logged out → redirected to `/login?callbackUrl=/share/<token>` → after login, lands on `/share/<token>` → added to `sharedWith`, redirected to `/`
- [ ] Shared user sees shared category in selector with `Users` icon; no delete button visible
- [ ] Owner and shared user both see real-time updates ("Lista atualizada" toast) when the other mutates the list
- [ ] Owner opening their own share link is a no-op (no duplicate in `sharedWith`)
- [ ] Opening an invalid share token shows "Link inválido ou expirado."
- [ ] Owner's "Limpar lista" does not affect shared category products

🤖 Generated with [Claude Code](https://claude.com/claude-code)