### PR TITLE
fix: align category select label to the left

### DIFF
--- a/src/components/category-select.tsx
+++ b/src/components/category-select.tsx
@@ -21,7 +21,7 @@ export function CategorySelect() {
   return (
     <Select value={selectedCategoryId || ''} onValueChange={handleCategoryChange}>
       <SelectTrigger className="flex h-16 w-full items-center justify-between rounded-[var(--radius-md)] border border-[var(--color-hairline)] bg-[var(--color-surface-card)] px-[14px] py-[13px] shadow-none [&>svg]:hidden">
-        <div className="flex flex-col gap-[3px]">
+        <div className="flex flex-col items-start gap-[3px]">
           <span className="text-[10px] font-bold leading-none text-[var(--color-muted)]">
             Lista atual
           </span>


### PR DESCRIPTION
## Summary
- Adds `items-start` to the inner flex column div in `CategorySelect` so the "Lista atual" label and category name align to the left edge

## Test plan
- [ ] Abrir o app e verificar que o label "Lista atual" aparece alinhado à esquerda no seletor de categoria

🤖 Generated with [Claude Code](https://claude.com/claude-code)