### PR TITLE
chore: add SVG logo assets and update favicon icon

### DIFF
--- a/public/logo-black.svg
+++ b/public/logo-black.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 180" role="img" aria-label="Easy List logo">
+  <g fill="none" stroke="#111111" stroke-width="13" stroke-linecap="round" stroke-linejoin="round" transform="translate(16 14) scale(.62)">
+    <path d="M105 38h45c34 0 61 27 61 61v23"/>
+    <path d="M189 211h-84c-34 0-61-27-61-61V99c0-34 27-61 61-61"/>
+    <path d="M81 89h81"/>
+    <path d="M81 127h66"/>
+    <path d="M81 165h37"/>
+    <path d="M147 157l31 31 56-72"/>
+  </g>
+  <text x="178" y="120" fill="#111111" font-family="Inter, Arial, Helvetica, sans-serif" font-size="82" font-weight="700" letter-spacing="-2">Easy List</text>
+</svg>

--- a/public/logo-white.svg
+++ b/public/logo-white.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 180" role="img" aria-label="Easy List logo white">
+  <g fill="none" stroke="#ffffff" stroke-width="13" stroke-linecap="round" stroke-linejoin="round" transform="translate(16 14) scale(.62)">
+    <path d="M105 38h45c34 0 61 27 61 61v23"/>
+    <path d="M189 211h-84c-34 0-61-27-61-61V99c0-34 27-61 61-61"/>
+    <path d="M81 89h81"/>
+    <path d="M81 127h66"/>
+    <path d="M81 165h37"/>
+    <path d="M147 157l31 31 56-72"/>
+  </g>
+  <text x="178" y="120" fill="#ffffff" font-family="Inter, Arial, Helvetica, sans-serif" font-size="82" font-weight="700" letter-spacing="-2">Easy List</text>
+</svg>

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="25 15 155 155">
+  <style>
+    :root { --c: #111111; }
+    @media (prefers-color-scheme: dark) { :root { --c: #ffffff; } }
+  </style>
+  <g fill="none" stroke="var(--c)" stroke-width="13" stroke-linecap="round" stroke-linejoin="round" transform="translate(16 14) scale(.62)">
+    <path d="M105 38h45c34 0 61 27 61 61v23"/>
+    <path d="M189 211h-84c-34 0-61-27-61-61V99c0-34 27-61 61-61"/>
+    <path d="M81 89h81"/>
+    <path d="M81 127h66"/>
+    <path d="M81 165h37"/>
+    <path d="M147 157l31 31 56-72"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- Add `public/logo-white.svg` and `public/logo-black.svg` — full horizontal logo (symbol + "Easy List" text) for white and black variants
- Add `src/app/icon.svg` — square icon with only the graphic symbol, auto-detected by Next.js App Router as the favicon; adapts to dark/light mode via `prefers-color-scheme`

## Test plan

- [ ] Check browser tab favicon in light mode (should be black symbol)
- [ ] Check browser tab favicon in dark mode (should be white symbol)
- [ ] Confirm `public/logo-white.svg` and `public/logo-black.svg` are accessible at their respective paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)