### PR TITLE
fix: blur trigger buttons before opening modals to prevent aria-hidden focus violation

### DIFF
--- a/src/components/category-card.tsx
+++ b/src/components/category-card.tsx
@@ -98,10 +98,11 @@ export function CategoryCard() {
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
+                    (e.currentTarget as HTMLButtonElement).blur();
                     handleRemoveClick(category);
                   }}
                   aria-label="Remover categoria"
-                  className="w-8 h-8 rounded-full bg-[#FEE2E2] flex items-center justify-center flex-shrink-0 transition-colors hover:bg-[#FECACA]"
+                  className="w-8 h-8 rounded-full bg-[var(--color-surface-card)] flex items-center justify-center flex-shrink-0"
                 >
                   <Trash2 className="h-4 w-4 text-[var(--color-error)]" />
                 </button>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -41,7 +41,10 @@ export function Footer() {
           <>
             <button
               type="button"
-              onClick={() => setCategoryDrawerOpen(true)}
+              onClick={(e) => {
+                (e.currentTarget as HTMLButtonElement).blur();
+                setCategoryDrawerOpen(true);
+              }}
               className="flex h-12 w-full items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)] transition-opacity hover:opacity-90 active:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--color-primary)]"
             >
               <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />

--- a/src/components/product-row.tsx
+++ b/src/components/product-row.tsx
@@ -96,7 +96,10 @@ export function ProductRow({
 
       <div className="flex h-[34px] items-center gap-2 flex-shrink-0">
         <button
-          onClick={() => onEdit(product)}
+          onClick={(e) => {
+            (e.currentTarget as HTMLButtonElement).blur();
+            onEdit(product);
+          }}
           disabled={isThisLoading || isDeleting}
           className="w-[34px] h-[34px] rounded-full bg-[var(--color-surface-card)] flex items-center justify-center disabled:opacity-50"
           aria-label="Editar produto"

--- a/src/components/state-card.tsx
+++ b/src/components/state-card.tsx
@@ -25,7 +25,10 @@ export function StateCard({ variant, onAdd }: StateCardProps) {
       </p>
 
       <button
-        onClick={isEmpty ? (onAdd ?? (() => {})) : () => router.push('/')}
+        onClick={(e) => {
+          (e.currentTarget as HTMLButtonElement).blur();
+          if (isEmpty) { onAdd?.(); } else { router.push('/'); }
+        }}
         className="text-[12px] font-semibold text-[var(--color-ink)] text-left"
       >
         {isEmpty ? 'Adicionar primeiro produto' : 'Voltar para Home'}

--- a/src/components/sticky-footer.tsx
+++ b/src/components/sticky-footer.tsx
@@ -34,7 +34,10 @@ export function StickyFooter({ products, onAddProduct }: StickyFooterProps) {
 
         {/* Add product button */}
         <button
-          onClick={onAddProduct}
+          onClick={(e) => {
+            (e.currentTarget as HTMLButtonElement).blur();
+            onAddProduct();
+          }}
           className="flex items-center justify-center gap-2 w-full h-12 rounded-[var(--radius-md)] bg-[var(--color-primary)]"
         >
           <Plus className="w-[18px] h-[18px] text-[var(--color-on-primary)]" />


### PR DESCRIPTION
## Summary

- Blur trigger buttons before opening modals/drawers to prevent the `aria-hidden` focus violation
- Fixed in all 5 components that open a modal/drawer on button click: `footer.tsx`, `category-card.tsx`, `sticky-footer.tsx`, `product-row.tsx`, `state-card.tsx`
- Also corrects the delete button background color on `category-card.tsx` to match the product row style (`--color-surface-card` instead of `#FEE2E2`)

## Test plan

- [ ] Open "Nova categoria" drawer — no `aria-hidden` console warning
- [ ] Open "Remover categoria" drawer — no warning
- [ ] Open "Adicionar produto" sheet — no warning
- [ ] Open "Editar produto" sheet via pencil button — no warning
- [ ] Open "Adicionar primeiro produto" sheet from empty state — no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)