### PR TITLE
feat: category listing improvements, skeletons, and UI polish

### DIFF
--- a/src/components/new-category-drawer.tsx
+++ b/src/components/new-category-drawer.tsx
@@ -44,7 +44,8 @@ export function NewCategoryDrawer({ open, onOpenChange }: NewCategoryDrawerProps
           className={cn(
             'fixed inset-x-0 bottom-0 z-50 flex flex-col',
             'rounded-t-2xl bg-background outline-none',
-            'shadow-[0_-4px_12px_rgba(0,0,0,0.08)]'
+            'shadow-[0_-4px_12px_rgba(0,0,0,0.08)]',
+            'sm:mx-auto sm:max-w-[460px] sm:rounded-2xl sm:mb-6'
           )}
         >
           <div className="flex flex-shrink-0 justify-center pt-2.5">


### PR DESCRIPTION
## Summary

- Separate owned and shared category lists on home screen
- Add `CategoryListSkeleton` and `CategoryPageSkeleton` loading states; wire into `CategoryClient`
- Simplify `CategoryCard` — move delete button inline, remove footer
- Add SVG logo assets and update favicon
- Fix `new-category` drawer width on large screens (matches product dialog `sm:max-w-[460px]`)
- Blur trigger buttons before opening modals to prevent aria-hidden focus violation

## Test Plan

- [ ] Home screen shows "Minhas listas" and "Compartilhadas" sections correctly
- [ ] Skeleton appears while categories are loading
- [ ] New category modal is constrained to 460px on desktop
- [ ] Delete button works inline on CategoryCard
- [ ] No aria-hidden focus warnings in browser console when opening modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)