### PR TITLE
feat: barcode product registration + SEO improvements

### DIFF
--- a/docs/superpowers/plans/2026-06-10-scan-button-footer.md
+++ b/docs/superpowers/plans/2026-06-10-scan-button-footer.md
@@ -1,0 +1,74 @@
+# Scan Button Footer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the scan action to the right of the add-product action and style it like the circular product row action buttons.
+
+**Architecture:** Keep the existing `StickyFooter` API and event handlers. Change only the footer button layout/classes so the primary add button remains wide and the scan action becomes a compact icon-only action.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS classes, Lucide icons, Next.js.
+
+---
+
+## File Structure
+
+- Modify `src/components/sticky-footer.tsx`: update the action row grid and scan button classes/content.
+
+## Task 1: Update Footer Scan Button
+
+**Files:**
+- Modify: `src/components/sticky-footer.tsx`
+
+- [ ] **Step 1: Replace the action button grid**
+
+In `src/components/sticky-footer.tsx`, replace the current action grid with:
+
+```tsx
+        <div className="grid grid-cols-[1fr_48px] gap-2">
+          <button
+            type="button"
+            onClick={(e) => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              onAddProduct();
+            }}
+            className="flex h-12 items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)]"
+          >
+            <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
+            <span className="text-[14px] font-semibold text-[var(--color-on-primary)]">
+              Adicionar produto
+            </span>
+          </button>
+
+          <button
+            type="button"
+            aria-label="Escanear produto"
+            onClick={(e) => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              onScanProduct();
+            }}
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-surface-card)]"
+          >
+            <ScanLine className="h-[15px] w-[15px] text-[var(--color-ink)]" />
+          </button>
+        </div>
+```
+
+- [ ] **Step 2: Verify**
+
+Run:
+
+```bash
+npm run lint
+npx tsc --noEmit
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-06-10-scan-button-footer-design.md docs/superpowers/plans/2026-06-10-scan-button-footer.md src/components/sticky-footer.tsx
+git commit -m "refactor(scan-button): alinha ação ao padrão de produto" -m "Alterações:" -m "- move botão Escanear para a direita do Adicionar produto" -m "- transforma escanear em ação circular icon-only" -m "- documenta spec e plano do ajuste visual"
+```

--- a/docs/superpowers/specs/2026-06-10-scan-button-footer-design.md
+++ b/docs/superpowers/specs/2026-06-10-scan-button-footer-design.md
@@ -1,0 +1,30 @@
+# Scan Button Footer Design
+
+**Date:** 2026-06-10
+**Status:** Approved
+
+## Problem
+
+The current **Escanear** action in `StickyFooter` is a secondary rectangular button placed to the left of **Adicionar produto**. It does not match the compact circular action style used by product edit/delete buttons in `ProductRow`.
+
+## Decision
+
+- Keep **Adicionar produto** as the primary wide action.
+- Move **Escanear** to the right of **Adicionar produto**.
+- Render **Escanear** as an icon-only circular button.
+- Match the product row action pattern: circular shape, centered icon, neutral surface background, and accessible `aria-label`.
+
+## Target Layout
+
+```text
+[ Adicionar produto                    ] [ scan ]
+```
+
+## Files
+
+- Modify `src/components/sticky-footer.tsx` only.
+
+## Verification
+
+- Run `npm run lint`.
+- Run `npx tsc --noEmit`.

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false },
+};
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -1,12 +1,15 @@
-'use client';
-
 import { Suspense } from 'react';
+import type { Metadata } from 'next';
 
 import { Main } from '@/components/main';
 import { Header } from '@/components/header';
 import { Skeleton } from '@/components/ui/skeleton';
 
 import { CategoryClient } from './category-client';
+
+export const metadata: Metadata = {
+  robots: { index: false },
+};
 
 function CategorySkeleton() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000'),
   title: 'Easy List',
   description: 'Sua lista de compras inteligente',
 };

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,31 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: '100%',
+          background: '#18181b',
+          color: '#ffffff',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <span style={{ fontSize: 64, fontWeight: 700 }}>Easy List</span>
+        <span style={{ fontSize: 28, marginTop: 16, opacity: 0.7 }}>
+          Sua lista de compras inteligente
+        </span>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,25 @@
-'use client';
+import type { Metadata } from 'next';
 
 import { Main } from '@/components/main';
 import { Footer } from '@/components/footer';
 import { Header } from '@/components/header';
 import { MainContent } from '@/components/main-content';
 import { CategoryCard } from '@/components/category-card';
+
+export const metadata: Metadata = {
+  title: 'Easy List — Sua lista de compras inteligente',
+  description: 'Organize suas compras de forma simples e compartilhe listas com sua família ou amigos.',
+  openGraph: {
+    title: 'Easy List — Sua lista de compras inteligente',
+    description: 'Organize suas compras de forma simples e compartilhe listas com sua família ou amigos.',
+    type: 'website',
+    locale: 'pt_BR',
+    url: process.env.NEXT_PUBLIC_BASE_URL,
+  },
+  twitter: {
+    card: 'summary_large_image',
+  },
+};
 
 export default function Home() {
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/category', '/api/', '/(auth)/'],
+      },
+    ],
+    sitemap: `${process.env.NEXT_PUBLIC_BASE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/share/[token]/opengraph-image.tsx
+++ b/src/app/share/[token]/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from 'next/og';
+
+import { getCategoryNameByToken } from '@/lib/share';
+
+export const runtime = 'edge';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function Image({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const name = await getCategoryNameByToken(token);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: '100%',
+          background: '#18181b',
+          color: '#ffffff',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <span style={{ fontSize: 24, opacity: 0.6 }}>Lista compartilhada</span>
+        <strong style={{ fontSize: 56, fontWeight: 700, marginTop: 12 }}>
+          {name ?? 'Easy List'}
+        </strong>
+        <span style={{ fontSize: 24, marginTop: 16, opacity: 0.5 }}>Toque para entrar</span>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -19,6 +19,7 @@ export async function generateMetadata({ params }: SharePageProps): Promise<Meta
 
   return {
     title,
+    description,
     openGraph: { title, description, type: 'website', locale: 'pt_BR' },
     twitter: { card: 'summary_large_image' },
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: process.env.NEXT_PUBLIC_BASE_URL!,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+  ];
+}

--- a/src/components/category-card.tsx
+++ b/src/components/category-card.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRouter } from 'next/navigation';
 import { Users, Trash2 } from 'lucide-react';
 import { isBefore, subWeeks } from 'date-fns';

--- a/src/components/sticky-footer.tsx
+++ b/src/components/sticky-footer.tsx
@@ -33,22 +33,7 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
           </span>
         </div>
 
-        <div className="grid grid-cols-[0.9fr_1.1fr] gap-2">
-          <button
-            type="button"
-            aria-label="Escanear produto"
-            onClick={(e) => {
-              (e.currentTarget as HTMLButtonElement).blur();
-              onScanProduct();
-            }}
-            className="flex h-12 items-center justify-center gap-2 rounded-[var(--radius-md)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] text-[var(--color-ink)]"
-          >
-            <ScanLine className="h-[18px] w-[18px]" />
-            <span className="text-[14px] font-semibold">
-              Escanear
-            </span>
-          </button>
-
+        <div className="grid grid-cols-[1fr_48px] gap-2">
           <button
             type="button"
             onClick={(e) => {
@@ -61,6 +46,18 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
             <span className="text-[14px] font-semibold text-[var(--color-on-primary)]">
               Adicionar produto
             </span>
+          </button>
+
+          <button
+            type="button"
+            aria-label="Escanear produto"
+            onClick={(e) => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              onScanProduct();
+            }}
+            className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-surface-card)]"
+          >
+            <ScanLine className="h-[15px] w-[15px] text-[var(--color-ink)]" />
           </button>
         </div>
       </div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,5 +33,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|opengraph-image).*)'],
 };


### PR DESCRIPTION
## Summary

- **Barcode registration:** Integra fluxo de leitura de código de barras para pré-popular produto com nome, marca e categoria; refatorações no scan-button para alinhar ao padrão de produto
- **SEO — discoverabilidade:** Home convertida para Server Component com metadata completa (OG tags, Twitter card, sitemap, robots.txt); rotas privadas marcadas com `noindex`
- **SEO — social previews:** Share links (`/share/[token]`) geram OG image dinâmica via `ImageResponse` mostrando o nome da categoria; `generateMetadata` com título e descrição dinâmicos

## Mudanças técnicas principais

- `GET /api/share/[token]` — lookup read-only do nome da categoria (sem consumir o token)
- `src/lib/share.ts` — utility `getCategoryNameByToken` edge-safe (fetch com URL absoluta)
- `src/app/share/[token]/share-client.tsx` — extração da lógica client da share page
- `src/app/opengraph-image.tsx` + `src/app/share/[token]/opengraph-image.tsx` — OG images via edge runtime
- `src/app/robots.ts` + `src/app/sitemap.ts` — robots.txt e sitemap.xml
- Middleware atualizado para não bloquear rotas SEO públicas

## Test Plan

- [ ] Build limpo: `npx next build` sem erros
- [ ] Home `/` tem `og:title`, `og:image` e `twitter:card` no `<head>`
- [ ] `/robots.txt` retorna regras corretas (allow `/`, disallow `/category`, `/api/`)
- [ ] `/sitemap.xml` retorna XML válido com a URL da home
- [ ] `/opengraph-image` retorna PNG 1200×630
- [ ] Link de share no WhatsApp exibe preview com nome da categoria
- [ ] `/category` e rotas auth têm `<meta name="robots" content="noindex">`
- [ ] Fluxo de leitura de barcode funciona end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)