### PR TITLE
feat: extract quantity and unit from AI-generated product names

### DIFF
--- a/docs/superpowers/plans/2026-06-11-ai-product-quantity-unit-extraction.md
+++ b/docs/superpowers/plans/2026-06-11-ai-product-quantity-unit-extraction.md
@@ -1,0 +1,442 @@
+# AI Product Quantity/Unit Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fazer a IA extrair quantidade e unidade de medida do nome do produto, preenchendo os campos correspondentes no cadastro em vez de incluí-los no título.
+
+**Architecture:** O system prompt é expandido para que Claude retorne `quantity?` e `unit?` por produto, limpando o nome. O servidor normaliza o campo `unit` para os valores do `UnitEnum` existente. O drawer de revisão exibe os campos extraídos com edição inline antes de criar os produtos.
+
+**Tech Stack:** Next.js 14, TypeScript, Anthropic SDK, Firebase, React
+
+---
+
+## File Map
+
+| Arquivo | O que muda |
+|---|---|
+| `src/types/interfaces.ts` | Expande `AiGeneratedList.products` com `quantity?` e `unit?` |
+| `src/app/api/ai/generate-list/route.ts` | Adiciona `normalizeUnit`, atualiza system prompt e tipo de retorno de `callClaude` |
+| `src/components/ai-review-list-drawer.tsx` | Atualiza estado, cards editáveis inline, payload de criação |
+
+---
+
+## Task 1: Expandir a interface `AiGeneratedList`
+
+**Files:**
+- Modify: `src/types/interfaces.ts`
+
+- [ ] **Step 1: Atualizar a interface**
+
+Substituir o conteúdo de `src/types/interfaces.ts` por:
+
+```ts
+export interface CategoryProps {
+  _id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  products?: Array<ProductProps>;
+  isShared?: boolean;
+}
+
+export interface ProductProps {
+  name: string;
+  _id?: string;
+  unit?: string;
+  price?: string;
+  barcode?: string;
+  createdAt: string;
+  quantity?: string;
+  updatedAt: string;
+  addToCart?: boolean;
+  categoryId?: string;
+  category?: CategoryProps;
+}
+
+export interface AiGeneratedList {
+  categoryName: string;
+  products: {
+    name: string;
+    unit?: string;
+    quantity?: string;
+  }[];
+}
+```
+
+- [ ] **Step 2: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros relacionados a `AiGeneratedList`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/interfaces.ts
+git commit -m "feat: expand AiGeneratedList products with quantity and unit fields"
+```
+
+---
+
+## Task 2: Atualizar a rota da IA — `normalizeUnit` + system prompt + tipo de retorno
+
+**Files:**
+- Modify: `src/app/api/ai/generate-list/route.ts`
+
+- [ ] **Step 1: Substituir o arquivo inteiro por:**
+
+```ts
+import { getToken } from 'next-auth/jwt';
+import Anthropic from '@anthropic-ai/sdk';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { UnitEnum } from '@/types/enums';
+import { authSecret } from '@/lib/auth-secret';
+import { AiGeneratedList } from '@/types/interfaces';
+import { getUserHistoryForAI } from '@/lib/firestore-domain';
+
+const client = new Anthropic();
+
+const UNIT_MAP: Record<string, UnitEnum> = {
+  g: UnitEnum.grams,
+  kg: UnitEnum.kg,
+  uni: UnitEnum.unit,
+};
+
+function normalizeUnit(raw?: string): UnitEnum | undefined {
+  if (!raw) return undefined;
+  return UNIT_MAP[raw.toLowerCase()] ?? UnitEnum.unit;
+}
+
+function buildSystemPrompt(history: { name: string; products: string[] }[]): string {
+  const base = `Você é um assistente de lista de compras.
+Responda APENAS com JSON válido, sem texto adicional, no formato:
+{ "categoryName": string, "products": [{ "name": string, "quantity"?: string, "unit"?: "kg" | "g" | "uni" }] }
+
+Gere entre 8 e 15 produtos por padrão, adequados ao contexto do pedido.
+Os nomes devem estar em português do Brasil.
+
+Regras de extração de quantidade e unidade:
+- Extraia quantidade e unidade do nome quando houver (ex: "1kg" → name:"Carne suína lombo em bifes", quantity:"1", unit:"kg")
+- Limpe o nome: remova a parte da quantidade/unidade extraída do campo name
+- Use apenas "kg", "g" ou "uni" para o campo unit
+- Para ml, l, litros, unidades, itens, pacotes → use "uni"
+- Ex: "10 unidades" → quantity:"10", unit:"uni"
+- Se não houver quantidade explícita, omita os campos quantity e unit`;
+
+  if (history.length === 0) return base;
+
+  const lines = history.map((c) => `- ${c.name}: ${c.products.join(', ')}`).join('\n');
+
+  return `${base}
+
+Histórico de compras do usuário:
+${lines}
+
+Use esse histórico como referência de preferências, mas adapte ao pedido atual.`;
+}
+
+async function callClaude(systemPrompt: string, userPrompt: string): Promise<AiGeneratedList> {
+  const message = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    system: systemPrompt,
+    messages: [{ role: 'user', content: userPrompt }],
+  });
+
+  const raw = message.content[0].type === 'text' ? message.content[0].text : '';
+  const text = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+
+  return JSON.parse(text);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = await getToken({ req: request, secret: authSecret });
+    const userId = token?.sub ?? null;
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const prompt: string = body?.prompt;
+
+    if (!prompt || typeof prompt !== 'string') {
+      return NextResponse.json({ error: 'Prompt é obrigatório' }, { status: 400 });
+    }
+
+    const history = await getUserHistoryForAI(userId);
+    const systemPrompt = buildSystemPrompt(history);
+
+    let result: AiGeneratedList;
+
+    try {
+      result = await callClaude(systemPrompt, prompt);
+    } catch {
+      result = await callClaude(systemPrompt, prompt);
+    }
+
+    if (!result.categoryName) {
+      result.categoryName = prompt.slice(0, 50);
+    }
+
+    if (!result.products || result.products.length === 0) {
+      return NextResponse.json(
+        { error: 'A IA não conseguiu gerar produtos para este pedido.' },
+        { status: 500 }
+      );
+    }
+
+    const normalized: AiGeneratedList = {
+      ...result,
+      products: result.products.map((p) => ({
+        ...p,
+        unit: normalizeUnit(p.unit),
+      })),
+    };
+
+    return NextResponse.json(normalized, { status: 200 });
+  } catch (error) {
+    console.error(error);
+
+    return NextResponse.json({ error: 'Erro ao gerar lista com IA' }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 2: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros de tipo.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/ai/generate-list/route.ts
+git commit -m "feat: extract quantity and unit from AI-generated product names"
+```
+
+---
+
+## Task 3: Atualizar `AiReviewListDrawer` — estado, cards editáveis e payload
+
+**Files:**
+- Modify: `src/components/ai-review-list-drawer.tsx`
+
+- [ ] **Step 1: Substituir o arquivo inteiro por:**
+
+```tsx
+'use client';
+
+import { toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+
+import { cn } from '@/lib/utils';
+import { UnitEnum } from '@/types/enums';
+import { useCategories } from '@/context';
+import { AiGeneratedList } from '@/types/interfaces';
+import { LoadingSpinner } from '@/components/loading-spinner';
+import { UnitSegmentedControl } from '@/components/ui/unit-segmented-control';
+import { ResponsiveProductDialog } from '@/components/responsive-product-dialog';
+
+type AiProduct = AiGeneratedList['products'][0];
+
+interface AiReviewListDrawerProps {
+  open?: boolean;
+  result: AiGeneratedList | null;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function AiReviewListDrawer({ open, result, onOpenChange }: AiReviewListDrawerProps) {
+  const router = useRouter();
+  const { markLocalMutation } = useCategories();
+  const [products, setProducts] = useState<AiProduct[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setProducts(result?.products ?? []);
+  }, [result]);
+
+  const removeProduct = (index: number) => {
+    setProducts((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const updateProduct = (index: number, updates: Partial<AiProduct>) => {
+    setProducts((prev) => prev.map((p, i) => (i === index ? { ...p, ...updates } : p)));
+  };
+
+  const handleConfirm = async () => {
+    if (!result || isSaving) return;
+
+    setIsSaving(true);
+    markLocalMutation(1 + products.length);
+
+    try {
+      const categoryResponse = await fetch('/api/categories', {
+        method: 'POST',
+        body: JSON.stringify({ name: result.categoryName }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!categoryResponse.ok) throw new Error('Failed to create category');
+
+      const { data: category } = await categoryResponse.json();
+
+      for (const product of products) {
+        const productResponse = await fetch('/api/products', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: product.name,
+            categoryId: category._id,
+            ...(product.unit ? { unit: product.unit } : {}),
+            ...(product.quantity ? { quantity: product.quantity } : {}),
+          }),
+        });
+
+        if (!productResponse.ok) throw new Error('Failed to create product');
+      }
+
+      onOpenChange?.(false);
+      router.push(`/category?id=${category._id}`);
+    } catch {
+      markLocalMutation(-(1 + products.length));
+      toast.error('Não foi possível criar a lista. Tente novamente.');
+      setIsSaving(false);
+    }
+  };
+
+  const buttonLabel =
+    products.length === 0 ? 'Criar categoria vazia' : `Criar lista (${products.length} itens)`;
+
+  return (
+    <ResponsiveProductDialog
+      open={open}
+      title={result?.categoryName ?? 'Lista gerada'}
+      description={`${products.length} ${products.length === 1 ? 'item gerado' : 'itens gerados'}`}
+      onOpenChange={onOpenChange}
+      footer={(
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={isSaving}
+          className="flex h-10 w-full flex-shrink-0 items-center justify-center gap-2 rounded-lg bg-foreground text-sm font-semibold text-background disabled:opacity-50"
+        >
+          {isSaving ? <LoadingSpinner size={16} /> : buttonLabel}
+        </button>
+      )}
+    >
+      <div className="flex flex-col gap-2 overflow-y-auto">
+        {products.map((product, index) => {
+          const hasExtracted = product.quantity !== undefined || product.unit !== undefined;
+
+          return (
+            <div
+              key={index}
+              className={cn(
+                'flex flex-col rounded-[var(--radius-lg)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] px-3',
+                hasExtracted ? 'gap-2 py-3' : 'h-[68px] justify-center'
+              )}
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-1 flex-col gap-[3px]">
+                  <span className="truncate text-[15px] font-semibold text-[var(--color-ink)]">
+                    {product.name}
+                  </span>
+                </div>
+
+                <div className="flex h-[34px] flex-shrink-0 items-center">
+                  <button
+                    type="button"
+                    aria-label={`Remover ${product.name}`}
+                    onClick={() => removeProduct(index)}
+                    className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-[var(--color-surface-card)]"
+                  >
+                    <Trash2 className="h-[15px] w-[15px] text-[var(--color-error)]" />
+                  </button>
+                </div>
+              </div>
+
+              {hasExtracted && (
+                <div className="flex items-center gap-2">
+                  <input
+                    min={0}
+                    step={0.1}
+                    type="number"
+                    inputMode="decimal"
+                    placeholder="Qtd."
+                    value={product.quantity ?? ''}
+                    onChange={(e) => updateProduct(index, { quantity: e.target.value })}
+                    className="h-8 w-20 rounded-lg border border-input bg-background px-2.5 text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  />
+                  <UnitSegmentedControl
+                    value={(product.unit as UnitEnum) ?? UnitEnum.unit}
+                    onChange={(val) => updateProduct(index, { unit: val })}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </ResponsiveProductDialog>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros de tipo.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ai-review-list-drawer.tsx
+git commit -m "feat: show and edit extracted quantity/unit in AI review drawer"
+```
+
+---
+
+## Task 4: Teste manual end-to-end
+
+- [ ] **Step 1: Iniciar o servidor de desenvolvimento**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Testar extração com unidade explícita**
+
+Abrir a aplicação → "Criar lista com IA" → digitar: `lista de churrasco para 10 pessoas`
+
+Verificar no drawer de revisão:
+- Produtos com quantidade explícita (ex: "Picanha 1kg") aparecem com nome limpo + input de quantidade preenchido + unidade selecionada
+- Produtos sem quantidade ficam com card compacto (sem segunda linha)
+- Input de quantidade é editável
+- Segmented control de unidade é clicável
+
+- [ ] **Step 3: Testar extração com "unidades/itens"**
+
+Digitar: `lista de material escolar para 1 aluno`
+
+Verificar: produtos como "10 lápis" → name:"lápis", quantity:"10", unit:"uni."
+
+- [ ] **Step 4: Verificar persistência no Firestore**
+
+Confirmar a lista → navegar para a categoria criada → abrir um produto que tinha quantidade → verificar que `quantity` e `unit` estão preenchidos na tela de edição do produto.
+
+- [ ] **Step 5: Testar remoção de produto**
+
+No drawer de revisão, remover um produto com segunda linha → confirmar que a lista restante está correta.

--- a/docs/superpowers/plans/2026-06-11-category-edit.md
+++ b/docs/superpowers/plans/2026-06-11-category-edit.md
@@ -1,0 +1,523 @@
+# Category Edit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permitir que o usuário renomeie uma categoria existente a partir de um botão de lápis no card da home, usando um drawer pré-preenchido com o nome atual.
+
+**Architecture:** Reutiliza o `NewCategoryDrawer` com uma prop `categoryToEdit` opcional que ativa o modo de edição (título, botão e handler trocados). O fluxo segue a pilha existente: contexto → `PUT /api/categories?id` → `updateCategory` no Firestore, com `onSnapshot` cuidando da sincronização automática.
+
+**Tech Stack:** Next.js 14, TypeScript, React Hook Form, Firestore Admin SDK (server), Firebase Client SDK (real-time), Sonner (toasts), Lucide React (ícones).
+
+---
+
+## Mapa de arquivos
+
+| Ação | Arquivo |
+|------|---------|
+| Modificar | `src/lib/firestore-domain.ts` |
+| Modificar | `src/app/api/categories/route.ts` |
+| Modificar | `src/context/CategoryContext.tsx` |
+| Modificar | `src/components/new-category-drawer.tsx` |
+| Modificar | `src/components/category-card.tsx` |
+
+---
+
+## Task 1: Firestore — `updateCategory`
+
+**Files:**
+- Modify: `src/lib/firestore-domain.ts`
+
+- [ ] **Step 1: Adicionar a função `updateCategory` após `deleteCategory`**
+
+Abrir `src/lib/firestore-domain.ts`. Localizar a função `deleteCategory` (linha ~194). Adicionar a função abaixo dela:
+
+```ts
+export async function updateCategory(userId: string, categoryId: string, name: string) {
+  const category = await getOwnedCategory(categoryId, userId);
+
+  if (!category) {
+    return null;
+  }
+
+  await categoriesCollection.doc(categoryId).update({
+    name,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  const updated = await categoriesCollection.doc(categoryId).get();
+
+  return categoryFromDoc(updated);
+}
+```
+
+`getOwnedCategory` já existe no arquivo (função privada). `categoryFromDoc` também já existe. `FieldValue` já é importado.
+
+- [ ] **Step 2: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/firestore-domain.ts
+git commit -m "feat: add updateCategory to firestore-domain"
+```
+
+---
+
+## Task 2: API — `PUT /api/categories`
+
+**Files:**
+- Modify: `src/app/api/categories/route.ts`
+
+- [ ] **Step 1: Adicionar `updateCategory` ao import de `firestore-domain`**
+
+Localizar a linha de import no topo do arquivo (linha ~5):
+
+```ts
+import {
+  createCategory,
+  deleteCategory,
+  getCategoryWithProducts,
+  getCategoriesWithProducts,
+} from '@/lib/firestore-domain';
+```
+
+Substituir por (staircase: menor → maior):
+
+```ts
+import {
+  createCategory,
+  deleteCategory,
+  updateCategory,
+  getCategoryWithProducts,
+  getCategoriesWithProducts,
+} from '@/lib/firestore-domain';
+```
+
+- [ ] **Step 2: Adicionar handler `PUT` ao final do arquivo**
+
+Adicionar após a função `DELETE`:
+
+```ts
+export async function PUT(request: NextRequest) {
+  try {
+    const userId = await getUserId(request);
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+
+    if (!id) {
+      return NextResponse.json({ error: 'ID da categoria é obrigatório' }, { status: 400 });
+    }
+
+    const data: CategoryData = await request.json();
+
+    if (!data.name || typeof data.name !== 'string' || !data.name.trim()) {
+      return NextResponse.json({ error: 'Nome da categoria é obrigatório' }, { status: 400 });
+    }
+
+    const category = await updateCategory(userId, id, data.name.trim());
+
+    if (!category) {
+      return NextResponse.json({ error: 'Categoria não encontrada' }, { status: 404 });
+    }
+
+    return NextResponse.json({ data: category }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+
+    return NextResponse.json({ error: 'Erro ao atualizar categoria' }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 3: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/categories/route.ts
+git commit -m "feat: add PUT /api/categories endpoint"
+```
+
+---
+
+## Task 3: Context — `updateCategory`
+
+**Files:**
+- Modify: `src/context/CategoryContext.tsx`
+
+- [ ] **Step 1: Adicionar `updateCategory` à interface `CategoriesContextType`**
+
+Localizar a interface `CategoriesContextType` (linha ~32). Substituir pelo bloco com a nova propriedade na posição correta (staircase, ordered by line length):
+
+```ts
+interface CategoriesContextType {
+  categories: CategoryProps[];
+  selectedCategoryId?: string;
+  isLoadingCategories: boolean;
+  errorCategories: string | null;
+  filteredCategory?: CategoryProps;
+  fetchCategories: () => Promise<void>;
+  markLocalMutation: (count?: number) => void;
+  removeCategory: (id: string) => Promise<void>;
+  setSelectedCategoryId: (categoryId: string) => void;
+  addCategory: (category: CategoryProps) => Promise<void>;
+  updateCategory: (id: string, name: string) => Promise<void>;
+  setCategories: React.Dispatch<React.SetStateAction<CategoryProps[]>>;
+}
+```
+
+- [ ] **Step 2: Adicionar a implementação `updateCategory` após `removeCategory`**
+
+Localizar a função `removeCategory` (linha ~311). Adicionar logo depois dela:
+
+```ts
+const updateCategory = async (id: string, name: string) => {
+  markLocalMutation();
+
+  const response = await fetch(`/api/categories?id=${id}`, {
+    method: 'PUT',
+    body: JSON.stringify({ name }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    localMutationCount.current -= 1;
+    toast('Erro ao atualizar categoria');
+    return;
+  }
+
+  toast('Categoria atualizada com sucesso');
+};
+```
+
+- [ ] **Step 3: Expor `updateCategory` no valor do provider**
+
+Localizar o `CategoriesContext.Provider` (linha ~380). Substituir o objeto `value` para incluir `updateCategory` na posição correta (staircase por nome da chave):
+
+```tsx
+value={{
+  categories,
+  addCategory,
+  setCategories,
+  removeCategory,
+  updateCategory,
+  errorCategories,
+  fetchCategories,
+  filteredCategory,
+  markLocalMutation,
+  selectedCategoryId,
+  isLoadingCategories,
+  setSelectedCategoryId,
+}}
+```
+
+- [ ] **Step 4: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/context/CategoryContext.tsx
+git commit -m "feat: add updateCategory to CategoryContext"
+```
+
+---
+
+## Task 4: `NewCategoryDrawer` — modo de edição
+
+**Files:**
+- Modify: `src/components/new-category-drawer.tsx`
+
+- [ ] **Step 1: Adicionar import de `Save` do lucide-react**
+
+Substituir a linha de import do lucide-react:
+
+```ts
+import { Plus } from 'lucide-react';
+```
+
+Por:
+
+```ts
+import { Plus, Save } from 'lucide-react';
+```
+
+- [ ] **Step 2: Atualizar a interface de props**
+
+Substituir:
+
+```ts
+interface NewCategoryDrawerProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+```
+
+Por (staircase: `open` 15 < `categoryToEdit` 32 < `onOpenChange` 40):
+
+```ts
+interface NewCategoryDrawerProps {
+  open?: boolean;
+  categoryToEdit?: CategoryProps;
+  onOpenChange?: (open: boolean) => void;
+}
+```
+
+- [ ] **Step 3: Reescrever o componente com suporte a modo edit**
+
+Substituir a função inteira `NewCategoryDrawer`:
+
+```tsx
+export function NewCategoryDrawer({ open, onOpenChange, categoryToEdit }: NewCategoryDrawerProps) {
+  const { addCategory, updateCategory } = useCategories();
+  const isEditMode = Boolean(categoryToEdit);
+
+  const methods = useForm<CategoryProps>({
+    defaultValues: {
+      name: categoryToEdit?.name ?? '',
+    },
+  });
+
+  const onSubmit = methods.handleSubmit((data) => {
+    if (isEditMode && categoryToEdit) {
+      updateCategory(categoryToEdit._id, data.name);
+    } else {
+      addCategory({ name: data.name } as CategoryProps);
+    }
+    methods.reset();
+    onOpenChange?.(false);
+  });
+
+  return (
+    <ResponsiveProductDialog
+      open={open}
+      title={isEditMode ? 'Editar categoria' : 'Nova categoria'}
+      description="Digite o nome e a categoria fica disponível imediatamente."
+      onOpenChange={(value) => {
+        if (!value) methods.reset();
+        onOpenChange?.(value);
+      }}
+      footer={(
+        <div className="flex flex-col gap-2.5">
+          <button
+            type="submit"
+            form="new-category-form"
+            className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-foreground text-sm font-semibold text-background"
+          >
+            {isEditMode ? (
+              <>
+                <Save className="h-5 w-5" />
+                Salvar
+              </>
+            ) : (
+              <>
+                <Plus className="h-5 w-5" />
+                Criar categoria
+              </>
+            )}
+          </button>
+
+          <p className="text-[13px] font-medium leading-[1.4] text-[#898989]">
+            Enter também {isEditMode ? 'salva' : 'cria'} quando o nome estiver preenchido.
+          </p>
+        </div>
+      )}
+    >
+      <FormProvider {...methods}>
+        <form id="new-category-form" onSubmit={onSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-[7px]">
+            <span className="text-[13px] font-bold leading-[1.35] text-foreground">
+              Categoria
+            </span>
+            <Input
+              required
+              id="name"
+              type="text"
+              placeholder="Nome da categoria"
+              className="h-10 rounded-lg px-3.5 text-base font-semibold"
+              {...methods.register('name')}
+            />
+          </div>
+        </form>
+      </FormProvider>
+    </ResponsiveProductDialog>
+  );
+}
+```
+
+- [ ] **Step 4: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/new-category-drawer.tsx
+git commit -m "feat: add edit mode to NewCategoryDrawer"
+```
+
+---
+
+## Task 5: `CategoryCard` — botão Pencil + drawer de edição
+
+**Files:**
+- Modify: `src/components/category-card.tsx`
+
+- [ ] **Step 1: Atualizar imports**
+
+Substituir o bloco de imports do arquivo inteiro por (staircase por linha completa, separando grupos externos / internos / relativos):
+
+```ts
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { isBefore, subWeeks } from 'date-fns';
+import { Users, Pencil, Trash2 } from 'lucide-react';
+import React, { useEffect, useCallback } from 'react';
+
+import { useCategories } from '@/context';
+import { CategoryProps } from '@/types/interfaces';
+import { CategoryListSkeleton } from '@/components/category-list-skeleton';
+
+import { NewCategoryDrawer } from './new-category-drawer';
+import { ConfirmRemoveCategoryDrawer } from './confirm-remove-category-drawer';
+```
+
+Nota: dentro do grupo `lucide-react`, os nomes são ordenados por tamanho: `Users`(5) < `Pencil`(6) = `Trash2`(6) — em empate, alfabético: P < T.
+
+- [ ] **Step 2: Adicionar estados e handler de edição**
+
+Localizar os quatro `React.useState` existentes (logo após a desestruturação do hook). Substituir o bloco de estados pelo bloco reordenado com os novos (staircase pela linha completa):
+
+```ts
+const [openEditDrawer, setOpenEditDrawer] = React.useState<boolean>(false);
+const [olderCategories, setOlderCategories] = React.useState<CategoryProps[]>();
+const [openRemoveDrawer, setOpenRemoveDrawer] = React.useState<boolean>(false);
+const [recentCategories, setRecentCategories] = React.useState<CategoryProps[]>();
+const [sharedCategories, setSharedCategories] = React.useState<CategoryProps[]>();
+const [selectedCategoryToEdit, setSelectedCategoryToEdit] = React.useState<CategoryProps>();
+const [selectedCategoryToRemove, setSelectedCategoryToRemove] = React.useState<CategoryProps>();
+```
+
+- [ ] **Step 3: Adicionar `handleEditClick` após `handleRemoveClick`**
+
+```ts
+const handleEditClick = useCallback((category: CategoryProps) => {
+  setSelectedCategoryToEdit(category);
+  setOpenEditDrawer(true);
+}, []);
+```
+
+- [ ] **Step 4: Atualizar `renderContent` — botão Pencil + dependências do useCallback**
+
+Localizar o botão de delete dentro de `renderContent`. Substituir o trecho `{!isShared && (<button...Trash2...))}` por um Fragment com dois botões:
+
+```tsx
+{!isShared && (
+  <>
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        (e.currentTarget as HTMLButtonElement).blur();
+        handleEditClick(category);
+      }}
+      aria-label="Editar categoria"
+      className="w-8 h-8 rounded-full bg-[var(--color-surface-card)] flex items-center justify-center flex-shrink-0"
+    >
+      <Pencil className="h-4 w-4 text-[var(--color-ink)]" />
+    </button>
+
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        (e.currentTarget as HTMLButtonElement).blur();
+        handleRemoveClick(category);
+      }}
+      aria-label="Remover categoria"
+      className="w-8 h-8 rounded-full bg-[var(--color-surface-card)] flex items-center justify-center flex-shrink-0"
+    >
+      <Trash2 className="h-4 w-4 text-[var(--color-error)]" />
+    </button>
+  </>
+)}
+```
+
+Atualizar também o array de dependências do `useCallback` de `renderContent` para incluir `handleEditClick`:
+
+```ts
+}, [router, handleEditClick, handleRemoveClick]);
+```
+
+- [ ] **Step 5: Adicionar o drawer de edição ao JSX de retorno**
+
+Localizar o bloco `{selectedCategoryToRemove && (<ConfirmRemoveCategoryDrawer.../>)}`. Adicionar antes dele:
+
+```tsx
+{selectedCategoryToEdit && (
+  <NewCategoryDrawer
+    key={selectedCategoryToEdit._id}
+    open={openEditDrawer}
+    onOpenChange={setOpenEditDrawer}
+    categoryToEdit={selectedCategoryToEdit}
+  />
+)}
+```
+
+A prop `key` garante que o formulário reinicia com os valores corretos ao trocar de categoria sem fechar o drawer.
+
+- [ ] **Step 6: Verificar tipos**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: sem erros.
+
+- [ ] **Step 7: Testar manualmente**
+
+Iniciar o servidor de desenvolvimento:
+
+```bash
+npm run dev
+```
+
+Checklist de verificação:
+- [ ] Home exibe botão de lápis à esquerda do lixo em cada categoria própria
+- [ ] Categorias compartilhadas **não** exibem o botão de lápis
+- [ ] Clicar no lápis abre o drawer com título "Editar categoria" e o campo pré-preenchido com o nome atual
+- [ ] Alterar o nome e clicar "Salvar" atualiza o nome na lista sem recarregar a página
+- [ ] Toast "Categoria atualizada com sucesso" aparece
+- [ ] Clicar em "Criar categoria" (botão +) ainda abre o drawer com título "Nova categoria" e campo vazio
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/category-card.tsx
+git commit -m "feat: add edit button and drawer to CategoryCard"
+```

--- a/docs/superpowers/specs/2026-06-11-ai-product-quantity-unit-extraction-design.md
+++ b/docs/superpowers/specs/2026-06-11-ai-product-quantity-unit-extraction-design.md
@@ -1,0 +1,173 @@
+# Design: Extração de Quantidade e Unidade na Geração de Listas via IA
+
+**Data:** 2026-06-11
+**Status:** Aprovado
+
+---
+
+## Problema
+
+A IA gera produtos com quantidade e unidade embutidos no nome (ex: "Carne suína lombo em bifes 1kg"). Os campos `quantity` e `unit` do modelo `ProductProps` existem na API mas não são alimentados pelo fluxo de geração via IA.
+
+---
+
+## Solução
+
+Expandir o schema de resposta da IA para incluir `quantity` e `unit` por produto. Claude extrai, estrutura e limpa o nome em uma única chamada. A `AiReviewListDrawer` exibe os campos extraídos com edição inline antes da confirmação.
+
+---
+
+## Decisões de Design
+
+| Decisão | Escolha |
+|---|---|
+| Unidades não suportadas (ml, l) | Mapear para `uni.` como fallback |
+| UX no drawer de revisão | Exibir e permitir edição inline |
+| Nome do produto | Limpar — remover a parte de quantidade/unidade extraída |
+
+---
+
+## Arquitetura
+
+**Arquivos afetados: 3 (nenhum novo)**
+
+### 1. `src/types/interfaces.ts`
+
+Expandir `AiGeneratedList.products` de `{ name: string }` para:
+
+```ts
+export interface AiGeneratedList {
+  categoryName: string;
+  products: {
+    name: string;
+    unit?: string;
+    quantity?: string;
+  }[];
+}
+```
+
+---
+
+### 2. `src/app/api/ai/generate-list/route.ts`
+
+**System prompt — formato de resposta atualizado:**
+
+```
+Responda APENAS com JSON válido, sem texto adicional, no formato:
+{
+  "categoryName": string,
+  "products": [{
+    "name": string,
+    "quantity"?: string,
+    "unit"?: "kg" | "g" | "uni"
+  }]
+}
+
+Regras de extração:
+- Extraia quantidade e unidade do nome quando houver (ex: "1kg" → quantity:"1", unit:"kg")
+- Limpe o nome: remova a parte de quantidade/unidade extraída do campo name
+- Use apenas os valores: "kg", "g", "uni" para o campo unit
+- Para ml, l, unidades, itens, pacotes → use "uni"
+- "10 unidades" → quantity:"10", unit:"uni"
+- Se não houver quantidade explícita, omita os campos quantity e unit
+```
+
+**Função `normalizeUnit`** (server-side):
+
+Mapeia a string retornada pela IA para o `UnitEnum` existente:
+
+```ts
+const UNIT_MAP: Record<string, UnitEnum> = {
+  kg: UnitEnum.kg,
+  g: UnitEnum.grams,
+  uni: UnitEnum.unit,
+};
+
+function normalizeUnit(raw?: string): UnitEnum | undefined {
+  if (!raw) return undefined;
+  return UNIT_MAP[raw.toLowerCase()] ?? undefined;
+}
+```
+
+A normalização é aplicada antes de retornar o resultado ao cliente, convertendo os campos `unit` de cada produto.
+
+**Tipo de retorno de `callClaude`** atualizado para refletir o novo schema.
+
+---
+
+### 3. `src/components/ai-review-list-drawer.tsx`
+
+**Estado local:**
+
+```ts
+// antes
+const [products, setProducts] = useState<{ name: string }[]>([]);
+
+// depois
+const [products, setProducts] = useState<AiGeneratedList['products']>([]);
+```
+
+**Cards de produto:**
+
+- Quando a IA extrai `quantity` ou `unit`: o card exibe uma segunda linha com input de quantidade (type="number", step=0.1) e segmented control de unidade (Un. / Kg / Gr)
+- Quando nada é extraído: card permanece como hoje (somente nome + botão remover)
+- Ambos os campos são editáveis inline no card
+
+Layout do card com dados extraídos:
+```
+┌──────────────────────────────────────────┐
+│ Carne suína lombo em bifes          [✕]  │
+│ [  1  ]  [ Un. ] [ Kg ] [ Gr ]           │
+└──────────────────────────────────────────┘
+```
+
+**Payload de criação:**
+
+```ts
+body: JSON.stringify({
+  name: product.name,
+  unit: product.unit,
+  quantity: product.quantity,
+  categoryId: category._id,
+})
+```
+
+Campos `unit` e `quantity` são enviados apenas quando presentes (não enviar `undefined` explicitamente).
+
+---
+
+## Fluxo Completo
+
+```
+Usuário digita prompt
+       ↓
+POST /api/ai/generate-list
+       ↓
+Claude retorna { categoryName, products: [{ name, quantity?, unit? }] }
+       ↓
+normalizeUnit() converte unit string → UnitEnum
+       ↓
+AiReviewListDrawer exibe produtos com quantity/unit editáveis
+       ↓
+Usuário confirma → POST /api/products (com name limpo + quantity + unit)
+```
+
+---
+
+## Cenários de Borda
+
+| Cenário | Comportamento |
+|---|---|
+| IA retorna "ml", "l", "litros" | Normaliza para `uni.`; usuário pode ajustar |
+| IA não extrai nada | Card permanece compacto; sem campos extras |
+| IA retorna quantity mas não unit | Input de quantidade aparece; unit padrão: `uni.` |
+| Nome após limpeza fica vazio | Improvável — Claude mantém o nome do produto |
+| Usuário edita quantity para valor inválido | Input type="number" previne valores não numéricos |
+
+---
+
+## Fora de Escopo
+
+- Expansão do `UnitEnum` com `ml` e `l`
+- Edição do nome do produto no drawer de revisão
+- Exibição de quantidade/unidade nos cards de produto já criados (comportamento existente)

--- a/docs/superpowers/specs/2026-06-11-category-edit-design.md
+++ b/docs/superpowers/specs/2026-06-11-category-edit-design.md
@@ -1,0 +1,117 @@
+# Category Edit — Design Spec
+
+**Date:** 2026-06-11
+**Status:** Approved
+
+## Overview
+
+Adiciona a capacidade de renomear uma categoria existente. O único campo editável é `name`. A edição é acionada pelo card da home (lista de categorias), através de um novo botão de lápis ao lado do botão de delete.
+
+## Fluxo geral
+
+```
+CategoryCard (botão Pencil)
+  → NewCategoryDrawer (modo edit, pré-preenchido)
+    → CategoryContext.updateCategory(id, name)
+      → PUT /api/categories?id={id}
+        → firestore-domain.updateCategory(userId, categoryId, name)
+          → Firestore (atualiza name + updatedAt)
+            → onSnapshot → CategoryContext re-render automático
+```
+
+O `onSnapshot` existente cuida da sincronização em tempo real. `markLocalMutation()` é chamado antes do fetch para evitar flicker.
+
+## API
+
+**Método:** `PUT /api/categories?id={categoryId}`
+**Arquivo:** `src/app/api/categories/route.ts` (novo método no arquivo existente)
+
+- Valida `userId` via JWT (mesmo padrão do `DELETE`)
+- Valida que `name` está presente e é string não-vazia
+- Verifica ownership: categoria deve pertencer ao `userId`
+- Retorna `200` com a categoria atualizada
+
+## Firestore
+
+**Função:** `updateCategory(userId: string, categoryId: string, name: string)`
+**Arquivo:** `src/lib/firestore-domain.ts`
+
+- Busca o documento e valida que `userId` coincide com o campo `userId` da categoria
+- Atualiza somente `name` e `updatedAt: FieldValue.serverTimestamp()`
+
+## Context
+
+**Método:** `updateCategory(id: string, name: string): Promise<void>`
+**Arquivo:** `src/context/CategoryContext.tsx`
+
+- Chama `markLocalMutation()` antes do fetch
+- `PUT /api/categories?id={id}` com `{ name }` no body
+- Toast de sucesso/erro seguindo o padrão existente (`addCategory`, `removeCategory`)
+- Exposto via `useCategories()`
+
+## Componente: `NewCategoryDrawer`
+
+**Arquivo:** `src/components/new-category-drawer.tsx`
+
+Nova prop opcional:
+
+```ts
+categoryToEdit?: CategoryProps
+```
+
+Comportamento quando `categoryToEdit` está presente (modo edit):
+
+| Elemento | Valor atual (create) | Valor no edit |
+|----------|----------------------|---------------|
+| Título   | "Nova categoria"     | "Editar categoria" |
+| Input    | vazio                | pré-preenchido com `categoryToEdit.name` |
+| Botão    | "Criar"              | "Salvar" |
+| Submit   | `addCategory()`      | `updateCategory(categoryToEdit._id, name)` |
+
+Quando `categoryToEdit` está ausente, comportamento idêntico ao atual.
+
+## Componente: `CategoryCard`
+
+**Arquivo:** `src/components/category-card.tsx`
+
+Para categorias não-compartilhadas (`!isShared`), adicionar à esquerda do `Trash2` (ordem: badge → pencil → trash):
+
+- Botão com ícone `Pencil` (lucide-react)
+- Mesmo estilo do botão de delete: circular, `bg-[var(--color-surface-card)]`, `h-8 w-8`
+- Cor do ícone: `text-[var(--color-ink)]`
+- `e.stopPropagation()` para não navegar
+- `(e.currentTarget as HTMLButtonElement).blur()` para remover foco (padrão do delete)
+
+Novos estados locais:
+
+```ts
+const [openEditDrawer, setOpenEditDrawer] = React.useState<boolean>(false);
+const [selectedCategoryToEdit, setSelectedCategoryToEdit] = React.useState<CategoryProps>();
+```
+
+Handler:
+
+```ts
+const handleEditClick = useCallback((category: CategoryProps) => {
+  setSelectedCategoryToEdit(category);
+  setOpenEditDrawer(true);
+}, []);
+```
+
+Renderização do drawer (ao lado do `ConfirmRemoveCategoryDrawer` existente):
+
+```tsx
+{selectedCategoryToEdit && (
+  <NewCategoryDrawer
+    open={openEditDrawer}
+    onOpenChange={setOpenEditDrawer}
+    categoryToEdit={selectedCategoryToEdit}
+  />
+)}
+```
+
+## Restrições
+
+- Edição disponível apenas para categorias próprias (`!isShared`)
+- Não é possível editar categorias compartilhadas com o usuário
+- Validação de ownership tanto no cliente (botão oculto para `isShared`) quanto no servidor (API verifica `userId`)

--- a/src/app/api/ai/generate-list/route.ts
+++ b/src/app/api/ai/generate-list/route.ts
@@ -20,6 +20,9 @@ function normalizeUnit(raw?: string): UnitEnum | undefined {
   return UNIT_MAP[raw.toLowerCase()] ?? UnitEnum.unit;
 }
 
+type ClaudeProduct = { name: string; unit?: string; quantity?: string };
+type ClaudeResponse = { categoryName: string; products: ClaudeProduct[] };
+
 function buildSystemPrompt(history: { name: string; products: string[] }[]): string {
   const base = `Você é um assistente de lista de compras.
 Responda APENAS com JSON válido, sem texto adicional, no formato:
@@ -48,7 +51,7 @@ ${lines}
 Use esse histórico como referência de preferências, mas adapte ao pedido atual.`;
 }
 
-async function callClaude(systemPrompt: string, userPrompt: string): Promise<AiGeneratedList> {
+async function callClaude(systemPrompt: string, userPrompt: string): Promise<ClaudeResponse> {
   const message = await client.messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 1024,
@@ -81,7 +84,7 @@ export async function POST(request: NextRequest) {
     const history = await getUserHistoryForAI(userId);
     const systemPrompt = buildSystemPrompt(history);
 
-    let result: AiGeneratedList;
+    let result: ClaudeResponse;
 
     try {
       result = await callClaude(systemPrompt, prompt);

--- a/src/app/api/ai/generate-list/route.ts
+++ b/src/app/api/ai/generate-list/route.ts
@@ -10,8 +10,8 @@ import { getUserHistoryForAI } from '@/lib/firestore-domain';
 const client = new Anthropic();
 
 const UNIT_MAP: Record<string, UnitEnum> = {
-  g: UnitEnum.grams,
   kg: UnitEnum.kg,
+  g: UnitEnum.grams,
   uni: UnitEnum.unit,
 };
 

--- a/src/app/api/ai/generate-list/route.ts
+++ b/src/app/api/ai/generate-list/route.ts
@@ -2,18 +2,39 @@ import { getToken } from 'next-auth/jwt';
 import Anthropic from '@anthropic-ai/sdk';
 import { NextRequest, NextResponse } from 'next/server';
 
+import { UnitEnum } from '@/types/enums';
 import { authSecret } from '@/lib/auth-secret';
+import { AiGeneratedList } from '@/types/interfaces';
 import { getUserHistoryForAI } from '@/lib/firestore-domain';
 
 const client = new Anthropic();
 
+const UNIT_MAP: Record<string, UnitEnum> = {
+  g: UnitEnum.grams,
+  kg: UnitEnum.kg,
+  uni: UnitEnum.unit,
+};
+
+function normalizeUnit(raw?: string): UnitEnum | undefined {
+  if (!raw) return undefined;
+  return UNIT_MAP[raw.toLowerCase()] ?? UnitEnum.unit;
+}
+
 function buildSystemPrompt(history: { name: string; products: string[] }[]): string {
   const base = `Você é um assistente de lista de compras.
 Responda APENAS com JSON válido, sem texto adicional, no formato:
-{ "categoryName": string, "products": [{ "name": string }] }
+{ "categoryName": string, "products": [{ "name": string, "quantity"?: string, "unit"?: "kg" | "g" | "uni" }] }
 
 Gere entre 8 e 15 produtos por padrão, adequados ao contexto do pedido.
-Os nomes devem estar em português do Brasil.`;
+Os nomes devem estar em português do Brasil.
+
+Regras de extração de quantidade e unidade:
+- Extraia quantidade e unidade do nome quando houver (ex: "1kg" → name:"Carne suína lombo em bifes", quantity:"1", unit:"kg")
+- Limpe o nome: remova a parte da quantidade/unidade extraída do campo name
+- Use apenas "kg", "g" ou "uni" para o campo unit
+- Para ml, l, litros, unidades, itens, pacotes → use "uni"
+- Ex: "10 unidades" → quantity:"10", unit:"uni"
+- Se não houver quantidade explícita, omita os campos quantity e unit`;
 
   if (history.length === 0) return base;
 
@@ -27,10 +48,7 @@ ${lines}
 Use esse histórico como referência de preferências, mas adapte ao pedido atual.`;
 }
 
-async function callClaude(
-  systemPrompt: string,
-  userPrompt: string
-): Promise<{ categoryName: string; products: { name: string }[] }> {
+async function callClaude(systemPrompt: string, userPrompt: string): Promise<AiGeneratedList> {
   const message = await client.messages.create({
     model: 'claude-sonnet-4-6',
     max_tokens: 1024,
@@ -63,7 +81,7 @@ export async function POST(request: NextRequest) {
     const history = await getUserHistoryForAI(userId);
     const systemPrompt = buildSystemPrompt(history);
 
-    let result: { categoryName: string; products: { name: string }[] };
+    let result: AiGeneratedList;
 
     try {
       result = await callClaude(systemPrompt, prompt);
@@ -82,7 +100,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    return NextResponse.json(result, { status: 200 });
+    const normalized: AiGeneratedList = {
+      ...result,
+      products: result.products.map((p) => ({
+        ...p,
+        unit: normalizeUnit(p.unit),
+      })),
+    };
+
+    return NextResponse.json(normalized, { status: 200 });
   } catch (error) {
     console.error(error);
 

--- a/src/components/ai-review-list-drawer.tsx
+++ b/src/components/ai-review-list-drawer.tsx
@@ -144,7 +144,7 @@ export function AiReviewListDrawer({ open, result, onOpenChange }: AiReviewListD
                     className="h-8 w-20 rounded-lg border border-input bg-background px-2.5 text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                   />
                   <UnitSegmentedControl
-                    value={(product.unit as UnitEnum) ?? UnitEnum.unit}
+                    value={product.unit ?? UnitEnum.unit}
                     onChange={(val) => updateProduct(index, { unit: val })}
                   />
                 </div>

--- a/src/components/ai-review-list-drawer.tsx
+++ b/src/components/ai-review-list-drawer.tsx
@@ -5,10 +5,15 @@ import { Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 
+import { cn } from '@/lib/utils';
+import { UnitEnum } from '@/types/enums';
 import { useCategories } from '@/context';
 import { AiGeneratedList } from '@/types/interfaces';
 import { LoadingSpinner } from '@/components/loading-spinner';
+import { UnitSegmentedControl } from '@/components/ui/unit-segmented-control';
 import { ResponsiveProductDialog } from '@/components/responsive-product-dialog';
+
+type AiProduct = AiGeneratedList['products'][0];
 
 interface AiReviewListDrawerProps {
   open?: boolean;
@@ -19,7 +24,7 @@ interface AiReviewListDrawerProps {
 export function AiReviewListDrawer({ open, result, onOpenChange }: AiReviewListDrawerProps) {
   const router = useRouter();
   const { markLocalMutation } = useCategories();
-  const [products, setProducts] = useState<{ name: string }[]>([]);
+  const [products, setProducts] = useState<AiProduct[]>([]);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
@@ -28,6 +33,10 @@ export function AiReviewListDrawer({ open, result, onOpenChange }: AiReviewListD
 
   const removeProduct = (index: number) => {
     setProducts((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const updateProduct = (index: number, updates: Partial<AiProduct>) => {
+    setProducts((prev) => prev.map((p, i) => (i === index ? { ...p, ...updates } : p)));
   };
 
   const handleConfirm = async () => {
@@ -50,8 +59,13 @@ export function AiReviewListDrawer({ open, result, onOpenChange }: AiReviewListD
       for (const product of products) {
         const productResponse = await fetch('/api/products', {
           method: 'POST',
-          body: JSON.stringify({ name: product.name, categoryId: category._id }),
           headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: product.name,
+            categoryId: category._id,
+            ...(product.unit ? { unit: product.unit } : {}),
+            ...(product.quantity ? { quantity: product.quantity } : {}),
+          }),
         });
 
         if (!productResponse.ok) throw new Error('Failed to create product');
@@ -87,29 +101,57 @@ export function AiReviewListDrawer({ open, result, onOpenChange }: AiReviewListD
       )}
     >
       <div className="flex flex-col gap-2 overflow-y-auto">
-        {products.map((product, index) => (
-          <div
-            key={index}
-            className="flex h-[68px] items-center gap-3 rounded-[var(--radius-lg)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] px-3 py-[10px]"
-          >
-            <div className="flex min-w-0 flex-1 flex-col gap-[3px]">
-              <span className="truncate text-[15px] font-semibold text-[var(--color-ink)]">
-                {product.name}
-              </span>
-            </div>
+        {products.map((product, index) => {
+          const hasExtracted = product.quantity !== undefined || product.unit !== undefined;
 
-            <div className="flex h-[34px] flex-shrink-0 items-center">
-              <button
-                type="button"
-                aria-label={`Remover ${product.name}`}
-                onClick={() => removeProduct(index)}
-                className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-[var(--color-surface-card)]"
-              >
-                <Trash2 className="h-[15px] w-[15px] text-[var(--color-error)]" />
-              </button>
+          return (
+            <div
+              key={index}
+              className={cn(
+                'flex flex-col rounded-[var(--radius-lg)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] px-3',
+                hasExtracted ? 'gap-2 py-3' : 'h-[68px] justify-center'
+              )}
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex min-w-0 flex-1 flex-col gap-[3px]">
+                  <span className="truncate text-[15px] font-semibold text-[var(--color-ink)]">
+                    {product.name}
+                  </span>
+                </div>
+
+                <div className="flex h-[34px] flex-shrink-0 items-center">
+                  <button
+                    type="button"
+                    aria-label={`Remover ${product.name}`}
+                    onClick={() => removeProduct(index)}
+                    className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-[var(--color-surface-card)]"
+                  >
+                    <Trash2 className="h-[15px] w-[15px] text-[var(--color-error)]" />
+                  </button>
+                </div>
+              </div>
+
+              {hasExtracted && (
+                <div className="flex items-center gap-2">
+                  <input
+                    min={0}
+                    step={0.1}
+                    type="number"
+                    inputMode="decimal"
+                    placeholder="Qtd."
+                    value={product.quantity ?? ''}
+                    onChange={(e) => updateProduct(index, { quantity: e.target.value })}
+                    className="h-8 w-20 rounded-lg border border-input bg-background px-2.5 text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  />
+                  <UnitSegmentedControl
+                    value={(product.unit as UnitEnum) ?? UnitEnum.unit}
+                    onChange={(val) => updateProduct(index, { unit: val })}
+                  />
+                </div>
+              )}
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </ResponsiveProductDialog>
   );

--- a/src/components/ai-review-list-drawer.tsx
+++ b/src/components/ai-review-list-drawer.tsx
@@ -64,7 +64,7 @@ export function AiReviewListDrawer({ open, result, onOpenChange }: AiReviewListD
             name: product.name,
             categoryId: category._id,
             ...(product.unit ? { unit: product.unit } : {}),
-            ...(product.quantity ? { quantity: product.quantity } : {}),
+            ...(product.quantity !== undefined && product.quantity !== '' ? { quantity: product.quantity } : {}),
           }),
         });
 
@@ -106,7 +106,7 @@ export function AiReviewListDrawer({ open, result, onOpenChange }: AiReviewListD
 
           return (
             <div
-              key={index}
+              key={`${product.name}-${index}`}
               className={cn(
                 'flex flex-col rounded-[var(--radius-lg)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] px-3',
                 hasExtracted ? 'gap-2 py-3' : 'h-[68px] justify-center'

--- a/src/lib/firestore-domain.ts
+++ b/src/lib/firestore-domain.ts
@@ -215,6 +215,23 @@ export async function deleteCategory(userId: string, categoryId: string) {
   return true;
 }
 
+export async function updateCategory(userId: string, categoryId: string, name: string) {
+  const category = await getOwnedCategory(categoryId, userId);
+
+  if (!category) {
+    return null;
+  }
+
+  await categoriesCollection.doc(categoryId).update({
+    name,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  const updated = await categoriesCollection.doc(categoryId).get();
+
+  return categoryFromDoc(updated);
+}
+
 export async function getProducts(userId: string) {
   const productsSnapshot = await productsCollection.where('userId', '==', userId).get();
   const categoriesSnapshot = await categoriesCollection.where('userId', '==', userId).get();

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,3 +1,5 @@
+import { UnitEnum } from '@/types/enums';
+
 export interface CategoryProps {
   _id: string;
   name: string;
@@ -25,7 +27,7 @@ export interface AiGeneratedList {
   categoryName: string;
   products: {
     name: string;
-    unit?: string;
+    unit?: UnitEnum;
     quantity?: string;
   }[];
 }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -22,6 +22,10 @@ export interface ProductProps {
 }
 
 export interface AiGeneratedList {
-  products: { name: string }[];
   categoryName: string;
+  products: {
+    name: string;
+    unit?: string;
+    quantity?: string;
+  }[];
 }


### PR DESCRIPTION
## Summary

- Expande o schema de resposta da IA para retornar `quantity?` e `unit?` por produto, limpando o nome (ex: "Carne suína lombo em bifes 1kg" → `name: "Carne suína lombo em bifes"`, `quantity: "1"`, `unit: UnitEnum.kg`)
- Adiciona `normalizeUnit` no servidor que mapeia strings do Claude (`"kg"`, `"g"`, `"uni"`) para `UnitEnum`, com fallback para `UnitEnum.unit` em unidades não reconhecidas
- Atualiza o drawer de revisão para exibir e permitir edição inline de quantidade e unidade antes de confirmar a criação da lista

## Detalhes Técnicos

- `AiGeneratedList.products[].unit` agora é `UnitEnum | undefined` (antes era `string`)
- `ClaudeResponse` é um tipo intermediário local à rota que representa o payload bruto do Claude antes da normalização
- Cards no drawer de revisão são compactos quando a IA não extrai quantidade/unidade, e expandem com campos editáveis quando extrai
- Quantidade `"0"` é preservada corretamente no payload (fix para falsy string)

## Test Plan

- [ ] Gerar lista com prompt de churrasco — verificar que produtos com quantidade explícita (ex: "Picanha 1kg") aparecem com nome limpo + quantidade + unidade no drawer
- [ ] Verificar que produtos sem quantidade ficam com card compacto
- [ ] Editar quantidade e unidade no drawer antes de confirmar
- [ ] Confirmar lista e verificar que `quantity` e `unit` estão preenchidos no produto criado
- [ ] Testar remoção de produto com segunda linha no drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)