### PR TITLE
feat: auto-organize list with AI subcategories

### DIFF
--- a/src/app/api/ai/organize-list/route.ts
+++ b/src/app/api/ai/organize-list/route.ts
@@ -8,8 +8,8 @@ import { organizeList, OrganizeProduct, getProductsForOrganize } from '@/lib/fir
 const client = new Anthropic();
 
 type ClaudeOrganizeResponse = {
-  subcategoryOrder: string[];
   products: OrganizeProduct[];
+  subcategoryOrder: string[];
 };
 
 const SYSTEM_PROMPT = `Classifique cada produto em uma subcategoria.

--- a/src/app/api/ai/organize-list/route.ts
+++ b/src/app/api/ai/organize-list/route.ts
@@ -1,7 +1,8 @@
 import { getToken } from 'next-auth/jwt';
 import Anthropic from '@anthropic-ai/sdk';
-import { authSecret } from '@/lib/auth-secret';
 import { NextRequest, NextResponse } from 'next/server';
+
+import { authSecret } from '@/lib/auth-secret';
 import { organizeList, OrganizeProduct, getProductsForOrganize } from '@/lib/firestore-domain';
 
 const client = new Anthropic();

--- a/src/app/api/ai/organize-list/route.ts
+++ b/src/app/api/ai/organize-list/route.ts
@@ -3,7 +3,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { authSecret } from '@/lib/auth-secret';
-import { OrganizeProduct, getProductsForOrganize, organizeList } from '@/lib/firestore-domain';
+import { organizeList, OrganizeProduct, getProductsForOrganize } from '@/lib/firestore-domain';
 
 const client = new Anthropic();
 
@@ -69,13 +69,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'São necessários pelo menos 2 produtos' }, { status: 400 });
     }
 
-    let result: ClaudeOrganizeResponse;
-
-    try {
-      result = await callClaude(products);
-    } catch {
-      result = await callClaude(products);
-    }
+    const result = await callClaude(products);
 
     const success = await organizeList(userId, categoryId, result.subcategoryOrder, result.products);
 

--- a/src/app/api/ai/organize-list/route.ts
+++ b/src/app/api/ai/organize-list/route.ts
@@ -1,0 +1,91 @@
+import { getToken } from 'next-auth/jwt';
+import Anthropic from '@anthropic-ai/sdk';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authSecret } from '@/lib/auth-secret';
+import { OrganizeProduct, getProductsForOrganize, organizeList } from '@/lib/firestore-domain';
+
+const client = new Anthropic();
+
+type ClaudeOrganizeResponse = {
+  subcategoryOrder: string[];
+  products: OrganizeProduct[];
+};
+
+const SYSTEM_PROMPT = `Classifique cada produto em uma subcategoria.
+Retorne APENAS JSON válido, sem texto adicional:
+{
+  "subcategoryOrder": string[],
+  "products": [{ "id": string, "subcategory": string }]
+}
+
+Nomes canônicos em PT-BR para listas de supermercado:
+"Frutas e Verduras", "Laticínios", "Carnes e Aves", "Padaria",
+"Mercearia", "Congelados", "Bebidas", "Limpeza", "Higiene e Beleza"
+
+Regras:
+- Mapeie variações para o canônico mais próximo (ex: "Proteínas" → "Carnes e Aves")
+- Crie novas subcategorias para listas fora do domínio supermercado
+- Todo produto deve ter uma subcategoria
+- subcategoryOrder deve refletir ordem lógica de percurso no supermercado ou contexto equivalente`;
+
+async function callClaude(products: { id: string; name: string }[]): Promise<ClaudeOrganizeResponse> {
+  const message = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: 'user', content: JSON.stringify(products) }],
+  });
+
+  const raw = message.content[0].type === 'text' ? message.content[0].text : '';
+  const text = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+
+  return JSON.parse(text);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = await getToken({ req: request, secret: authSecret });
+    const userId = token?.sub ?? null;
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const categoryId: string = body?.categoryId;
+
+    if (!categoryId || typeof categoryId !== 'string') {
+      return NextResponse.json({ error: 'categoryId é obrigatório' }, { status: 400 });
+    }
+
+    const products = await getProductsForOrganize(userId, categoryId);
+
+    if (!products) {
+      return NextResponse.json({ error: 'Categoria não encontrada' }, { status: 404 });
+    }
+
+    if (products.length < 2) {
+      return NextResponse.json({ error: 'São necessários pelo menos 2 produtos' }, { status: 400 });
+    }
+
+    let result: ClaudeOrganizeResponse;
+
+    try {
+      result = await callClaude(products);
+    } catch {
+      result = await callClaude(products);
+    }
+
+    const success = await organizeList(userId, categoryId, result.subcategoryOrder, result.products);
+
+    if (!success) {
+      return NextResponse.json({ error: 'Erro ao salvar organização' }, { status: 500 });
+    }
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Erro ao organizar lista' }, { status: 500 });
+  }
+}

--- a/src/app/api/ai/organize-list/route.ts
+++ b/src/app/api/ai/organize-list/route.ts
@@ -1,8 +1,7 @@
 import { getToken } from 'next-auth/jwt';
 import Anthropic from '@anthropic-ai/sdk';
-import { NextRequest, NextResponse } from 'next/server';
-
 import { authSecret } from '@/lib/auth-secret';
+import { NextRequest, NextResponse } from 'next/server';
 import { organizeList, OrganizeProduct, getProductsForOrganize } from '@/lib/firestore-domain';
 
 const client = new Anthropic();

--- a/src/app/category/category-client.tsx
+++ b/src/app/category/category-client.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { toast } from 'sonner';
 import { useSearchParams } from 'next/navigation';
-import { useMemo, useState, useEffect } from 'react';
+import { Fragment, useMemo, useState, useEffect } from 'react';
 
 import { ProductProps } from '@/types/interfaces';
 import { StateCard } from '@/components/state-card';
@@ -11,6 +11,7 @@ import { ProductRow } from '@/components/product-row';
 import { useProducts, useCategories } from '@/context';
 import { GroupHeader } from '@/components/group-header';
 import { StickyFooter } from '@/components/sticky-footer';
+import { SubcategoryHeader } from '@/components/subcategory-header';
 import { CategoryHeroCard } from '@/components/category-hero-card';
 import { UnitEnum, AddOrEditProductTypeEnum } from '@/types/enums';
 import { BarcodeScannerSheet } from '@/components/barcode-scanner-sheet';
@@ -18,9 +19,37 @@ import { ProductManagerSheet } from '@/components/product-manager-sheet';
 import { CategoryPageSkeleton } from '@/components/category-page-skeleton';
 import { BarcodeLookupResult, BarcodeProductPreview } from '@/components/barcode-product-preview';
 
+function groupProductsBySubcategory(
+  products: ProductProps[],
+  subcategoryOrder: string[]
+): { subcategory: string; products: ProductProps[] }[] {
+  const orderedMap = new Map<string, ProductProps[]>(
+    subcategoryOrder.map(s => [s, []])
+  );
+  const outros: ProductProps[] = [];
+
+  for (const product of products) {
+    if (product.subcategory && orderedMap.has(product.subcategory)) {
+      orderedMap.get(product.subcategory)!.push(product);
+    } else {
+      outros.push(product);
+    }
+  }
+
+  const result: { subcategory: string; products: ProductProps[] }[] = [];
+  for (const [sub, prods] of orderedMap) {
+    if (prods.length > 0) result.push({ subcategory: sub, products: prods });
+  }
+  if (outros.length > 0) {
+    result.push({ subcategory: 'Outros', products: outros });
+  }
+
+  return result;
+}
+
 export function CategoryClient() {
   const searchParams = useSearchParams();
-  const { setSelectedCategoryId, filteredCategory, isLoadingCategories } = useCategories();
+  const { setSelectedCategoryId, filteredCategory, isLoadingCategories, markLocalMutation } = useCategories();
   const { removeProduct, toggleCart, managerProduct, isProductLoading } = useProducts();
 
   const categoryId = searchParams.get('id');
@@ -33,6 +62,7 @@ export function CategoryClient() {
   const [lookupResult, setLookupResult] = useState<BarcodeLookupResult | null>(null);
   const [scannerInitialProduct, setScannerInitialProduct] = useState<Partial<ProductProps> | undefined>();
   const [isBarcodeBusy, setIsBarcodeBusy] = useState(false);
+  const [isOrganizing, setIsOrganizing] = useState(false);
 
   useEffect(() => {
     if (!categoryId) return;
@@ -145,6 +175,29 @@ export function CategoryClient() {
     setEditSheetOpen(true);
   };
 
+  const handleOrganize = async () => {
+    if (!filteredCategory?._id || isOrganizing) return;
+
+    setIsOrganizing(true);
+    markLocalMutation((filteredCategory.products?.length ?? 0) + 1);
+
+    try {
+      const response = await fetch('/api/ai/organize-list', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ categoryId: filteredCategory._id }),
+      });
+
+      if (!response.ok) throw new Error('API error');
+
+      toast.success('Lista organizada!');
+    } catch {
+      toast.error('Não foi possível organizar a lista. Tente novamente.');
+    } finally {
+      setIsOrganizing(false);
+    }
+  };
+
   const { productsNotInCart, productsInCart } = useMemo(() => {
     const all = filteredCategory?.products ?? [];
     const sorted = [...all].sort((a, b) =>
@@ -168,6 +221,7 @@ export function CategoryClient() {
   }
 
   const allProducts = filteredCategory.products ?? [];
+  const subcategoryOrder = filteredCategory?.subcategoryOrder;
 
   return (
     <>
@@ -185,6 +239,8 @@ export function CategoryClient() {
         <CategoryHeroCard
           category={filteredCategory}
           products={allProducts}
+          isOrganizing={isOrganizing}
+          onOrganize={handleOrganize}
         />
 
         {allProducts.length === 0 && (
@@ -203,17 +259,35 @@ export function CategoryClient() {
               title="Fora do carrinho"
               count={productsNotInCart.length}
             />
-            {productsNotInCart.map(p => (
-              <ProductRow
-                key={p._id}
-                product={p}
-                variant="pending"
-                onToggleCart={toggleCart}
-                onEdit={handleEditProduct}
-                onDelete={removeProduct}
-                isProductLoading={isProductLoading}
-              />
-            ))}
+            {subcategoryOrder
+              ? groupProductsBySubcategory(productsNotInCart, subcategoryOrder).map(group => (
+                  <Fragment key={group.subcategory}>
+                    <SubcategoryHeader title={group.subcategory} count={group.products.length} />
+                    {group.products.map(p => (
+                      <ProductRow
+                        key={p._id}
+                        product={p}
+                        variant="pending"
+                        onToggleCart={toggleCart}
+                        onEdit={handleEditProduct}
+                        onDelete={removeProduct}
+                        isProductLoading={isProductLoading}
+                      />
+                    ))}
+                  </Fragment>
+                ))
+              : productsNotInCart.map(p => (
+                  <ProductRow
+                    key={p._id}
+                    product={p}
+                    variant="pending"
+                    onToggleCart={toggleCart}
+                    onEdit={handleEditProduct}
+                    onDelete={removeProduct}
+                    isProductLoading={isProductLoading}
+                  />
+                ))
+            }
           </>
         )}
 
@@ -223,17 +297,35 @@ export function CategoryClient() {
               title="Carrinho"
               count={productsInCart.length}
             />
-            {productsInCart.map(p => (
-              <ProductRow
-                key={p._id}
-                product={p}
-                variant="cart"
-                onToggleCart={toggleCart}
-                onEdit={handleEditProduct}
-                onDelete={removeProduct}
-                isProductLoading={isProductLoading}
-              />
-            ))}
+            {subcategoryOrder
+              ? groupProductsBySubcategory(productsInCart, subcategoryOrder).map(group => (
+                  <Fragment key={group.subcategory}>
+                    <SubcategoryHeader title={group.subcategory} count={group.products.length} />
+                    {group.products.map(p => (
+                      <ProductRow
+                        key={p._id}
+                        product={p}
+                        variant="cart"
+                        onToggleCart={toggleCart}
+                        onEdit={handleEditProduct}
+                        onDelete={removeProduct}
+                        isProductLoading={isProductLoading}
+                      />
+                    ))}
+                  </Fragment>
+                ))
+              : productsInCart.map(p => (
+                  <ProductRow
+                    key={p._id}
+                    product={p}
+                    variant="cart"
+                    onToggleCart={toggleCart}
+                    onEdit={handleEditProduct}
+                    onDelete={removeProduct}
+                    isProductLoading={isProductLoading}
+                  />
+                ))
+            }
           </>
         )}
       </div>

--- a/src/app/category/category-client.tsx
+++ b/src/app/category/category-client.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { toast } from 'sonner';
 import { useSearchParams } from 'next/navigation';
-import { Fragment, useMemo, useState, useEffect } from 'react';
+import { useMemo, Fragment, useState, useEffect } from 'react';
 
 import { ProductProps } from '@/types/interfaces';
 import { StateCard } from '@/components/state-card';
@@ -11,9 +11,9 @@ import { ProductRow } from '@/components/product-row';
 import { useProducts, useCategories } from '@/context';
 import { GroupHeader } from '@/components/group-header';
 import { StickyFooter } from '@/components/sticky-footer';
-import { SubcategoryHeader } from '@/components/subcategory-header';
 import { CategoryHeroCard } from '@/components/category-hero-card';
 import { UnitEnum, AddOrEditProductTypeEnum } from '@/types/enums';
+import { SubcategoryHeader } from '@/components/subcategory-header';
 import { BarcodeScannerSheet } from '@/components/barcode-scanner-sheet';
 import { ProductManagerSheet } from '@/components/product-manager-sheet';
 import { CategoryPageSkeleton } from '@/components/category-page-skeleton';
@@ -261,32 +261,32 @@ export function CategoryClient() {
             />
             {subcategoryOrder
               ? groupProductsBySubcategory(productsNotInCart, subcategoryOrder).map(group => (
-                  <Fragment key={group.subcategory}>
-                    <SubcategoryHeader title={group.subcategory} count={group.products.length} />
-                    {group.products.map(p => (
-                      <ProductRow
-                        key={p._id}
-                        product={p}
-                        variant="pending"
-                        onToggleCart={toggleCart}
-                        onEdit={handleEditProduct}
-                        onDelete={removeProduct}
-                        isProductLoading={isProductLoading}
-                      />
-                    ))}
-                  </Fragment>
-                ))
+                <Fragment key={group.subcategory}>
+                  <SubcategoryHeader title={group.subcategory} count={group.products.length} />
+                  {group.products.map(p => (
+                    <ProductRow
+                      key={p._id}
+                      product={p}
+                      variant="pending"
+                      onToggleCart={toggleCart}
+                      onEdit={handleEditProduct}
+                      onDelete={removeProduct}
+                      isProductLoading={isProductLoading}
+                    />
+                  ))}
+                </Fragment>
+              ))
               : productsNotInCart.map(p => (
-                  <ProductRow
-                    key={p._id}
-                    product={p}
-                    variant="pending"
-                    onToggleCart={toggleCart}
-                    onEdit={handleEditProduct}
-                    onDelete={removeProduct}
-                    isProductLoading={isProductLoading}
-                  />
-                ))
+                <ProductRow
+                  key={p._id}
+                  product={p}
+                  variant="pending"
+                  onToggleCart={toggleCart}
+                  onEdit={handleEditProduct}
+                  onDelete={removeProduct}
+                  isProductLoading={isProductLoading}
+                />
+              ))
             }
           </>
         )}
@@ -299,32 +299,32 @@ export function CategoryClient() {
             />
             {subcategoryOrder
               ? groupProductsBySubcategory(productsInCart, subcategoryOrder).map(group => (
-                  <Fragment key={group.subcategory}>
-                    <SubcategoryHeader title={group.subcategory} count={group.products.length} />
-                    {group.products.map(p => (
-                      <ProductRow
-                        key={p._id}
-                        product={p}
-                        variant="cart"
-                        onToggleCart={toggleCart}
-                        onEdit={handleEditProduct}
-                        onDelete={removeProduct}
-                        isProductLoading={isProductLoading}
-                      />
-                    ))}
-                  </Fragment>
-                ))
+                <Fragment key={group.subcategory}>
+                  <SubcategoryHeader title={group.subcategory} count={group.products.length} />
+                  {group.products.map(p => (
+                    <ProductRow
+                      key={p._id}
+                      product={p}
+                      variant="cart"
+                      onToggleCart={toggleCart}
+                      onEdit={handleEditProduct}
+                      onDelete={removeProduct}
+                      isProductLoading={isProductLoading}
+                    />
+                  ))}
+                </Fragment>
+              ))
               : productsInCart.map(p => (
-                  <ProductRow
-                    key={p._id}
-                    product={p}
-                    variant="cart"
-                    onToggleCart={toggleCart}
-                    onEdit={handleEditProduct}
-                    onDelete={removeProduct}
-                    isProductLoading={isProductLoading}
-                  />
-                ))
+                <ProductRow
+                  key={p._id}
+                  product={p}
+                  variant="cart"
+                  onToggleCart={toggleCart}
+                  onEdit={handleEditProduct}
+                  onDelete={removeProduct}
+                  isProductLoading={isProductLoading}
+                />
+              ))
             }
           </>
         )}

--- a/src/components/category-hero-card.tsx
+++ b/src/components/category-hero-card.tsx
@@ -2,9 +2,10 @@
 
 import { toast } from 'sonner';
 import { useState } from 'react';
-import { Share2, ChevronUp, ChevronDown, ShoppingCart } from 'lucide-react';
+import { Share2, Sparkles, ChevronUp, ChevronDown, ShoppingCart } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import { LoadingSpinner } from '@/components/loading-spinner';
 import { ProductProps, CategoryProps } from '@/types/interfaces';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 
@@ -27,9 +28,11 @@ function StatPill({ value, label }: StatPillProps) {
 interface CategoryHeroCardProps {
   category: CategoryProps;
   products: ProductProps[];
+  isOrganizing?: boolean;
+  onOrganize?: () => Promise<void>;
 }
 
-export function CategoryHeroCard({ category, products }: CategoryHeroCardProps) {
+export function CategoryHeroCard({ category, products, isOrganizing, onOrganize }: CategoryHeroCardProps) {
   const [isOpen, setIsOpen] = useState(true);
 
   async function handleShare() {
@@ -91,14 +94,35 @@ export function CategoryHeroCard({ category, products }: CategoryHeroCardProps) 
         </div>
 
         {!category.isShared && (
-          <Button
-            variant="outline"
-            onClick={handleShare}
-            className="h-10 w-full border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] [&_svg]:size-4"
-          >
-            <Share2 aria-hidden="true" />
-            Compartilhar lista
-          </Button>
+          <>
+            <Button
+              variant="outline"
+              onClick={handleShare}
+              className="h-10 w-full border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] [&_svg]:size-4"
+            >
+              <Share2 aria-hidden="true" />
+              Compartilhar lista
+            </Button>
+
+            <Button
+              variant="outline"
+              onClick={onOrganize}
+              disabled={isOrganizing || products.length < 2}
+              className="h-10 w-full border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] disabled:opacity-50 [&_svg]:size-4"
+            >
+              {isOrganizing ? (
+                <>
+                  <LoadingSpinner size={16} />
+                  Organizando...
+                </>
+              ) : (
+                <>
+                  <Sparkles aria-hidden="true" />
+                  Organizar lista
+                </>
+              )}
+            </Button>
+          </>
         )}
 
         <div>

--- a/src/components/category-hero-card.tsx
+++ b/src/components/category-hero-card.tsx
@@ -26,13 +26,13 @@ function StatPill({ value, label }: StatPillProps) {
 }
 
 interface CategoryHeroCardProps {
+  isOrganizing?: boolean;
   category: CategoryProps;
   products: ProductProps[];
-  isOrganizing?: boolean;
   onOrganize?: () => Promise<void>;
 }
 
-export function CategoryHeroCard({ category, products, isOrganizing, onOrganize }: CategoryHeroCardProps) {
+export function CategoryHeroCard({ isOrganizing, category, products, onOrganize }: CategoryHeroCardProps) {
   const [isOpen, setIsOpen] = useState(true);
 
   async function handleShare() {

--- a/src/components/product-manager-sheet.tsx
+++ b/src/components/product-manager-sheet.tsx
@@ -33,7 +33,7 @@ export const ProductManagerSheet = ({
   initialProduct,
 }: ProductManagerSheetProps) => {
   const { managerProduct, isProductLoading } = useProducts();
-  const { categories, selectedCategoryId, isLoadingCategories } = useCategories();
+  const { categories, filteredCategory, selectedCategoryId, isLoadingCategories } = useCategories();
 
   const isEdit = type === AddOrEditProductTypeEnum.edit;
   const formId = React.useId();
@@ -43,6 +43,7 @@ export const ProductManagerSheet = ({
       name: '',
       price: '',
       quantity: '',
+      subcategory: '',
       addToCart: false,
       unit: UnitEnum.unit,
       categoryId:
@@ -90,6 +91,7 @@ export const ProductManagerSheet = ({
             addToCart: data.addToCart,
             createdAt: data.createdAt,
             updatedAt: data.updatedAt,
+            subcategory: data.subcategory,
             categoryId: selectedCategoryId || data.category?._id,
           });
         } catch (error) {
@@ -264,6 +266,23 @@ export const ProductManagerSheet = ({
               checked={!!addToCart}
               onCheckedChange={(val) => methods.setValue('addToCart', val)}
             />
+
+            {isEdit && filteredCategory?.subcategoryOrder && (
+              <div className="flex flex-col gap-[7px]">
+                <span className="text-[13px] font-bold leading-[1.35] text-foreground">
+                  Seção
+                </span>
+                <select
+                  className="h-10 rounded-lg border border-input bg-background px-3.5 text-base font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  {...methods.register('subcategory')}
+                >
+                  {filteredCategory.subcategoryOrder.map(sub => (
+                    <option key={sub} value={sub}>{sub}</option>
+                  ))}
+                  <option value="">Outros</option>
+                </select>
+              </div>
+            )}
           </form>
         </FormProvider>
       )}

--- a/src/components/product-manager-sheet.tsx
+++ b/src/components/product-manager-sheet.tsx
@@ -279,7 +279,7 @@ export const ProductManagerSheet = ({
                   {filteredCategory.subcategoryOrder.map(sub => (
                     <option key={sub} value={sub}>{sub}</option>
                   ))}
-                  <option value="">Outros</option>
+                  <option key="" value="">Outros</option>
                 </select>
               </div>
             )}

--- a/src/components/subcategory-header.tsx
+++ b/src/components/subcategory-header.tsx
@@ -1,6 +1,6 @@
 interface SubcategoryHeaderProps {
-  title: string;
   count: number;
+  title: string;
 }
 
 export function SubcategoryHeader({ title, count }: SubcategoryHeaderProps) {

--- a/src/components/subcategory-header.tsx
+++ b/src/components/subcategory-header.tsx
@@ -1,0 +1,17 @@
+interface SubcategoryHeaderProps {
+  title: string;
+  count: number;
+}
+
+export function SubcategoryHeader({ title, count }: SubcategoryHeaderProps) {
+  return (
+    <div className="flex items-center gap-2 px-1">
+      <span className="text-[13px] font-semibold text-[var(--color-muted)]">
+        {title}
+      </span>
+      <span className="text-[12px] font-medium text-[var(--color-muted)]">
+        {count}
+      </span>
+    </div>
+  );
+}

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -101,9 +101,9 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
         const catRef: CategoryProps = {
           _id: cat.id,
           name: cat.name,
+          isShared: cat.isShared,
           createdAt: cat.createdAt,
           updatedAt: cat.updatedAt,
-          isShared: cat.isShared,
           subcategoryOrder: cat.subcategoryOrder,
         };
 
@@ -112,15 +112,15 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
           .map((p) => ({
             _id: p.id,
             name: p.name,
-            price: p.price,
-            quantity: p.quantity,
             unit: p.unit,
-            categoryId: p.categoryId,
-            addToCart: Boolean(p.addToCart),
-            subcategory: p.subcategory,
+            price: p.price,
+            category: catRef,
+            quantity: p.quantity,
             createdAt: p.createdAt,
             updatedAt: p.updatedAt,
-            category: catRef,
+            categoryId: p.categoryId,
+            subcategory: p.subcategory,
+            addToCart: Boolean(p.addToCart),
           }))
           .sort((a, b) => (a.name || '').localeCompare(b.name || '', 'pt-BR'));
 

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -15,18 +15,20 @@ interface RawCategory {
   name: string;
   createdAt: string;
   updatedAt: string;
+  subcategoryOrder?: string[];
 }
 
 interface RawProduct {
   id: string;
   name: string;
-  categoryId: string;
-  price?: string;
-  quantity?: string;
   unit?: string;
-  addToCart?: boolean;
+  price?: string;
   createdAt: string;
+  quantity?: string;
   updatedAt: string;
+  categoryId: string;
+  addToCart?: boolean;
+  subcategory?: string;
 }
 
 interface CategoriesContextType {
@@ -102,6 +104,7 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
           createdAt: cat.createdAt,
           updatedAt: cat.updatedAt,
           isShared: cat.isShared,
+          subcategoryOrder: cat.subcategoryOrder,
         };
 
         const products: ProductProps[] = allRawProds
@@ -114,6 +117,7 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
             unit: p.unit,
             categoryId: p.categoryId,
             addToCart: Boolean(p.addToCart),
+            subcategory: p.subcategory,
             createdAt: p.createdAt,
             updatedAt: p.updatedAt,
             category: catRef,
@@ -170,6 +174,7 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
             name: data.name as string,
             createdAt: timestampToIso(data.createdAt),
             updatedAt: timestampToIso(data.updatedAt),
+            subcategoryOrder: data.subcategoryOrder as string[] | undefined,
           };
         });
 
@@ -193,13 +198,14 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
           return {
             id: doc.id,
             name: data.name as string,
-            categoryId: data.categoryId as string,
-            price: data.price as string | undefined,
-            quantity: data.quantity as string | undefined,
             unit: data.unit as string | undefined,
-            addToCart: data.addToCart as boolean | undefined,
+            price: data.price as string | undefined,
             createdAt: timestampToIso(data.createdAt),
+            quantity: data.quantity as string | undefined,
             updatedAt: timestampToIso(data.updatedAt),
+            categoryId: data.categoryId as string,
+            addToCart: data.addToCart as boolean | undefined,
+            subcategory: data.subcategory as string | undefined,
           };
         });
 
@@ -225,6 +231,7 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
             name: data.name as string,
             createdAt: timestampToIso(data.createdAt),
             updatedAt: timestampToIso(data.updatedAt),
+            subcategoryOrder: data.subcategoryOrder as string[] | undefined,
           };
         });
 
@@ -261,13 +268,14 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
               return {
                 id: doc.id,
                 name: data.name as string,
-                categoryId: data.categoryId as string,
-                price: data.price as string | undefined,
-                quantity: data.quantity as string | undefined,
                 unit: data.unit as string | undefined,
-                addToCart: data.addToCart as boolean | undefined,
+                price: data.price as string | undefined,
                 createdAt: timestampToIso(data.createdAt),
+                quantity: data.quantity as string | undefined,
                 updatedAt: timestampToIso(data.updatedAt),
+                categoryId: data.categoryId as string,
+                addToCart: data.addToCart as boolean | undefined,
+                subcategory: data.subcategory as string | undefined,
               };
             });
 

--- a/src/lib/firestore-domain.ts
+++ b/src/lib/firestore-domain.ts
@@ -36,6 +36,7 @@ function categoryFromDoc(doc: FirebaseFirestore.DocumentSnapshot): CategoryProps
     name: data.name,
     createdAt: timestampToIso(data.createdAt),
     updatedAt: timestampToIso(data.updatedAt),
+    subcategoryOrder: data.subcategoryOrder as string[] | undefined,
   };
 }
 
@@ -58,6 +59,7 @@ function productFromDoc(
     barcode: data.barcode,
     quantity: data.quantity,
     categoryId: data.categoryId,
+    subcategory: data.subcategory,
     addToCart: Boolean(data.addToCart),
     createdAt: timestampToIso(data.createdAt),
     updatedAt: timestampToIso(data.updatedAt),
@@ -261,6 +263,7 @@ export async function createProduct(userId: string, product: ProductWrite) {
     categoryId: product.categoryId,
     barcode: product.barcode ?? null,
     quantity: product.quantity ?? null,
+    subcategory: product.subcategory ?? null,
     addToCart: Boolean(product.addToCart),
     createdAt: FieldValue.serverTimestamp(),
     updatedAt: FieldValue.serverTimestamp(),
@@ -304,6 +307,7 @@ export async function updateProduct(userId: string, productId: string, product: 
     quantity: product.quantity ?? null,
     addToCart: Boolean(product.addToCart),
     updatedAt: FieldValue.serverTimestamp(),
+    subcategory: product.subcategory ?? null,
   });
 
   const updatedProductDoc = await productsCollection.doc(productId).get();
@@ -401,4 +405,51 @@ export async function getUserHistoryForAI(
   }
 
   return result;
+}
+
+export type OrganizeProduct = { id: string; subcategory: string };
+
+export async function getProductsForOrganize(
+  userId: string,
+  categoryId: string
+): Promise<{ id: string; name: string }[] | null> {
+  const category = await getOwnedCategory(categoryId, userId);
+  if (!category) return null;
+
+  const snapshot = await productsCollection
+    .where('userId', '==', userId)
+    .where('categoryId', '==', categoryId)
+    .get();
+
+  return snapshot.docs.map(doc => ({
+    id: doc.id,
+    name: doc.data().name as string,
+  }));
+}
+
+export async function organizeList(
+  userId: string,
+  categoryId: string,
+  subcategoryOrder: string[],
+  productClassifications: OrganizeProduct[]
+): Promise<boolean> {
+  const category = await getOwnedCategory(categoryId, userId);
+  if (!category) return false;
+
+  const batch = firestore.batch();
+
+  for (const { id, subcategory } of productClassifications) {
+    batch.update(productsCollection.doc(id), {
+      subcategory,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  batch.update(categoriesCollection.doc(categoryId), {
+    subcategoryOrder,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  await batch.commit();
+  return true;
 }

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -11,8 +11,8 @@ export interface CategoryProps {
 }
 
 export interface ProductProps {
-  name: string;
   _id?: string;
+  name: string;
   unit?: string;
   price?: string;
   barcode?: string;

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -5,8 +5,9 @@ export interface CategoryProps {
   name: string;
   createdAt: string;
   updatedAt: string;
-  products?: Array<ProductProps>;
   isShared?: boolean;
+  subcategoryOrder?: string[];
+  products?: Array<ProductProps>;
 }
 
 export interface ProductProps {
@@ -20,6 +21,7 @@ export interface ProductProps {
   updatedAt: string;
   addToCart?: boolean;
   categoryId?: string;
+  subcategory?: string;
   category?: CategoryProps;
 }
 


### PR DESCRIPTION
## Summary

- Adds "Organizar lista" button to `CategoryHeroCard` that classifies all products into subcategories using Claude (`claude-sonnet-4-6`) via `POST /api/ai/organize-list`
- Subcategories and ordering are persisted in Firestore via batch write (`subcategory` on products, `subcategoryOrder` on categories) and reflected in real-time for all list members
- Products are rendered grouped by subcategory in both "Fora do carrinho" and "Carrinho" groups when `subcategoryOrder` is defined; falls back to flat list otherwise
- Adds "Secao" field to `ProductManagerSheet` (edit mode only) so users can manually override a product's subcategory

## Test Plan

- [ ] Open a category with >= 2 products — "Organizar lista" button visible in CategoryHeroCard (collapsed section)
- [ ] Click "Organizar lista" — button shows spinner + "Organizando...", then toast "Lista organizada!" and products grouped under subcategory headers
- [ ] Open shared list in incognito — grouping visible, "Organizar lista" button NOT visible
- [ ] Edit a product in an organized list — "Secao" select visible with current subcategory pre-selected; changing it moves the product to the correct group
- [ ] Add a new product after organizing — appears in "Outros" group

Generated with [Claude Code](https://claude.com/claude-code)
