### PR TITLE
fix(api): increase max_tokens to 4096 on organize-list

### DIFF
--- a/src/app/api/ai/organize-list/route.ts
+++ b/src/app/api/ai/organize-list/route.ts
@@ -34,7 +34,7 @@ Regras:
 async function callClaude(products: { id: string; name: string }[]): Promise<ClaudeOrganizeResponse> {
   const message = await client.messages.create({
     model: 'claude-sonnet-4-6',
-    max_tokens: 1024,
+    max_tokens: 4096,
     system: SYSTEM_PROMPT,
     messages: [{ role: 'user', content: JSON.stringify(products) }],
   });


### PR DESCRIPTION
Aumenta `max_tokens` de 1024 para 4096 no endpoint `/api/ai/organize-list` para evitar JSON truncado quando a lista tem muitos produtos.

Fix não incluído no merge do PR #100.