### PR TITLE
feat(ui): collapsible category sections with subcategory grouping

### DIFF
--- a/src/app/category/category-client.tsx
+++ b/src/app/category/category-client.tsx
@@ -292,7 +292,10 @@ export function CategoryClient() {
         )}
 
         {productsNotInCart.length > 0 && (
-          <>
+          <div className={cn(
+            'flex flex-col rounded-[var(--radius-xl)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] p-4 dark:border-[var(--color-surface-dark-elevated)] dark:bg-[var(--color-surface-dark-elevated)]',
+            !collapsedSections.has('pending') && 'gap-4'
+          )}>
             <SectionHeader
               title="Fora do carrinho"
               count={productsNotInCart.length}
@@ -351,11 +354,14 @@ export function CategoryClient() {
                 </div>
               </div>
             </div>
-          </>
+          </div>
         )}
 
         {productsInCart.length > 0 && (
-          <>
+          <div className={cn(
+            'flex flex-col rounded-[var(--radius-xl)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] p-4 dark:border-[var(--color-surface-dark-elevated)] dark:bg-[var(--color-surface-dark-elevated)]',
+            !collapsedSections.has('cart') && 'gap-4'
+          )}>
             <SectionHeader
               title="Carrinho"
               count={productsInCart.length}
@@ -414,7 +420,7 @@ export function CategoryClient() {
                 </div>
               </div>
             </div>
-          </>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Adds collapsible **SectionHeader** (`Fora do carrinho` / `Carrinho`) — button element with count pill (`color-primary`) and `ChevronDown` that rotates −90° when collapsed
- Adds collapsible **SubcategoryHeader** — chevron + title + count, all in `color-muted`, used when the list is organised into subcategories
- Replaces the full-width "Organizar lista" button in **CategoryHeroCard** with a compact row of 32×32 ghost icon buttons: `Sparkles` (always visible when ≥ 2 products) + `ListX` (visible only while subcategory grouping is active)
- Adds **DELETE /api/categories/[id]/grouping** route and `removeGrouping` domain function to clear `subcategoryOrder`
- Wraps each product section group in a card container matching the hero card aesthetic — `canvas` bg + `hairline` border in light mode, `surface-dark-elevated` in dark mode, `radius-xl` corners, 16 px padding, conditional gap to avoid phantom spacing when collapsed

## Test plan

- [ ] Tap "Fora do carrinho" header → section collapses, chevron points left; tap again → expands
- [ ] Tap "Carrinho" header → same collapse/expand behaviour
- [ ] With subcategory grouping active: tap a subcategory header → its products collapse independently
- [ ] Sparkles button visible when list has ≥ 2 products; triggers AI grouping
- [ ] ListX button visible only after grouping is applied; removes grouping on tap
- [ ] Both sections render as cards in light and dark mode — correct background, border and radius
- [ ] Collapsed card height is compact (no phantom gap below the header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)