### PR TITLE
feat(SGMD-0001): exibe rótulos nos botões de IA e reordena ações da categoria

### DIFF
--- a/src/components/category-hero-card.tsx
+++ b/src/components/category-hero-card.tsx
@@ -97,6 +97,30 @@ export function CategoryHeroCard({ isOrganizing, category, products, isRemovingG
 
         {!category.isShared && (
           <>
+            <div className="flex items-center gap-2.5">
+              <Button
+                variant="outline"
+                onClick={onOrganize}
+                disabled={isOrganizing || products.length < 2}
+                className="h-10 flex-1 border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] disabled:opacity-50 [&_svg]:size-4"
+              >
+                {isOrganizing ? <LoadingSpinner size={14} /> : <Sparkles aria-hidden="true" />}
+                Organizar lista
+              </Button>
+
+              {(category.subcategoryOrder?.length ?? 0) > 0 && (
+                <Button
+                  variant="outline"
+                  onClick={onRemoveGrouping}
+                  disabled={isRemovingGrouping}
+                  className="h-10 flex-1 border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] disabled:opacity-50 [&_svg]:size-4"
+                >
+                  {isRemovingGrouping ? <LoadingSpinner size={14} /> : <ListX aria-hidden="true" />}
+                  Remover agrupamento
+                </Button>
+              )}
+            </div>
+
             <Button
               variant="outline"
               onClick={handleShare}
@@ -105,32 +129,6 @@ export function CategoryHeroCard({ isOrganizing, category, products, isRemovingG
               <Share2 aria-hidden="true" />
               Compartilhar lista
             </Button>
-
-            <div className="flex items-center gap-1">
-              <Button
-                size="icon"
-                variant="ghost"
-                onClick={onOrganize}
-                aria-label="Organizar lista"
-                disabled={isOrganizing || products.length < 2}
-                className="h-8 w-8 disabled:opacity-50 [&_svg]:size-4"
-              >
-                {isOrganizing ? <LoadingSpinner size={14} /> : <Sparkles aria-hidden="true" />}
-              </Button>
-
-              {(category.subcategoryOrder?.length ?? 0) > 0 && (
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  onClick={onRemoveGrouping}
-                  aria-label="Remover agrupamento"
-                  disabled={isRemovingGrouping}
-                  className="h-8 w-8 disabled:opacity-50 [&_svg]:size-4"
-                >
-                  {isRemovingGrouping ? <LoadingSpinner size={14} /> : <ListX aria-hidden="true" />}
-                </Button>
-              )}
-            </div>
           </>
         )}
 


### PR DESCRIPTION
Link do Jira https://goomer.atlassian.net/browse/SGMD-0001

## Contexto

Os botões "Organizar lista" e "Remover agrupamento" no card de categoria exibiam apenas os ícones (`Sparkles` e `ListX`), o que dificultava o entendimento da função de cada um. A ideia é dar a essas ações o mesmo tratamento visual do botão "Compartilhar lista", que já mostra ícone + rótulo, e reorganizar a ordem das ações para que as ações de IA fiquem em destaque acima do compartilhamento.

## O que foi feito

- Aplicado o design do botão **"Compartilhar lista"** (`variant="outline"`, altura `h-10`, borda, `bg-surface-card`, texto `font-semibold`) aos botões "Organizar lista" e "Remover agrupamento", que antes usavam `variant="ghost"` no formato `size="icon"`.
- Os botões agora exibem o **rótulo por extenso** ao lado do ícone, em vez de só o ícone.
- O wrapper dos botões de IA passou a ser **inline** (`flex` com `gap-2.5` e cada botão em `flex-1`), dividindo a linha igualmente; quando só existe "Organizar lista", ele ocupa a largura toda.
- O wrapper dos botões de IA foi **movido para antes** do botão "Compartilhar lista".
- Removidos os `aria-label` desses dois botões, já que o texto visível agora serve de nome acessível.