### PR TITLE
feat(SGMD-0002): adiciona seleção de categoria e aprimora hero card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# design tooling artifacts (impeccable / playwright sessions)
+.playwright-mcp/
+.impeccable/critique/
+.impeccable/design.json
+/hero-critique-*.png

--- a/src/app/category/category-client.tsx
+++ b/src/app/category/category-client.tsx
@@ -12,6 +12,7 @@ import { ProductRow } from '@/components/product-row';
 import { useProducts, useCategories } from '@/context';
 import { StickyFooter } from '@/components/sticky-footer';
 import { SectionHeader } from '@/components/section-header';
+import { CategorySelect } from '@/components/category-select';
 import { CategoryHeroCard } from '@/components/category-hero-card';
 import { UnitEnum, AddOrEditProductTypeEnum } from '@/types/enums';
 import { SubcategoryHeader } from '@/components/subcategory-header';
@@ -178,8 +179,27 @@ export function CategoryClient() {
     setEditSheetOpen(true);
   };
 
+  const handleUndoOrganize = async (categoryId: string) => {
+    markLocalMutation(1);
+
+    try {
+      const response = await fetch(`/api/categories/${categoryId}/grouping`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) throw new Error('API error');
+
+      toast.success('Organização desfeita.');
+    } catch {
+      markLocalMutation(-1);
+      toast.error('Não foi possível desfazer. Tente novamente.');
+    }
+  };
+
   const handleOrganize = async () => {
     if (!filteredCategory?._id || isOrganizing) return;
+
+    const categoryId = filteredCategory._id;
 
     setIsOrganizing(true);
     markLocalMutation((filteredCategory.products?.length ?? 0) + 1);
@@ -188,12 +208,18 @@ export function CategoryClient() {
       const response = await fetch('/api/ai/organize-list', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ categoryId: filteredCategory._id }),
+        body: JSON.stringify({ categoryId }),
       });
 
       if (!response.ok) throw new Error('API error');
 
-      toast.success('Lista organizada!');
+      toast.success('Lista organizada!', {
+        duration: 8000,
+        action: {
+          label: 'Desfazer',
+          onClick: () => { void handleUndoOrganize(categoryId); },
+        },
+      });
     } catch {
       toast.error('Não foi possível organizar a lista. Tente novamente.');
     } finally {
@@ -267,9 +293,7 @@ export function CategoryClient() {
             Home
           </Link>
           <span className="text-[12px] text-[var(--color-muted)]">/</span>
-          <span className="text-[12px] font-semibold text-[var(--color-muted)]" aria-current="page">
-            {filteredCategory.name}
-          </span>
+          <CategorySelect />
         </nav>
 
         <CategoryHeroCard

--- a/src/components/category-hero-card.tsx
+++ b/src/components/category-hero-card.tsx
@@ -2,28 +2,12 @@
 
 import { toast } from 'sonner';
 import { useState } from 'react';
-import { ListX, Share2, Sparkles, ChevronUp, ChevronDown, ShoppingCart } from 'lucide-react';
+import { ListX, Share2, Sparkles, ChevronUp, ChevronDown } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/loading-spinner';
 import { ProductProps, CategoryProps } from '@/types/interfaces';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
-
-import { CategorySelect } from './category-select';
-
-interface StatPillProps {
-  value: number;
-  label: string;
-}
-
-function StatPill({ value, label }: StatPillProps) {
-  return (
-    <div className="flex flex-1 items-center gap-1.5 rounded-full bg-[var(--color-surface-soft)] px-3 py-[9px]">
-      <span className="text-[13px] font-medium text-[var(--color-ink)]">{value}</span>
-      <span className="text-[13px] font-medium text-[var(--color-muted)]">{label}</span>
-    </div>
-  );
-}
 
 interface CategoryHeroCardProps {
   isOrganizing?: boolean;
@@ -48,9 +32,9 @@ export function CategoryHeroCard({ isOrganizing, category, products, isRemovingG
       toast.error('Não foi possível copiar o link');
     }
   }
-  const pendingCount = products.filter(p => !p.addToCart).length;
   const cartCount = products.filter(p => p.addToCart).length;
   const totalCount = products.length;
+  const cartPercent = totalCount > 0 ? Math.round((cartCount / totalCount) * 100) : 0;
   const toggleLabel = isOpen ? 'Recolher detalhes da categoria' : 'Expandir detalhes da categoria';
 
   return (
@@ -59,83 +43,86 @@ export function CategoryHeroCard({ isOrganizing, category, products, isRemovingG
       onOpenChange={setIsOpen}
       className="flex flex-col gap-3.5 rounded-[var(--radius-xl)] border border-[var(--color-hairline)] bg-[var(--color-canvas)] p-[18px] [font-family:var(--font-body)]"
     >
-      <div className="relative flex flex-col gap-2.5 pr-10">
-        <div className="flex flex-col gap-1">
-          <h1 className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-[var(--color-ink)] [font-family:var(--font-display)]">
-            {category.name}
-          </h1>
+      <div className={`relative flex flex-col gap-2.5 ${!category.isShared ? 'pr-10' : ''}`}>
+        <h1 className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-[var(--color-ink)] [font-family:var(--font-display)] [overflow-wrap:anywhere]">
+          {category.name}
+        </h1>
 
-          <p className="text-[13px] font-medium text-[var(--color-muted)]">
-            {totalCount} produto{totalCount !== 1 ? 's' : ''} nesta lista
-          </p>
-        </div>
-
-        <div className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[var(--color-surface-soft)] px-2.5 py-2">
-          <ShoppingCart className="h-3.5 w-3.5 text-[var(--color-success)]" />
-          <span className="text-[13px] font-medium text-[var(--color-ink)]">
-            {cartCount} no carrinho
-          </span>
-        </div>
-
-        <CollapsibleTrigger
-          className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center rounded-full border border-[var(--color-hairline)] bg-[var(--color-surface-soft)] text-[var(--color-ink)] transition-colors hover:bg-[var(--color-surface-card)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ink)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-canvas)]"
-          aria-label={toggleLabel}
-        >
-          {isOpen ? (
-            <ChevronUp className="h-4 w-4" aria-hidden="true" />
-          ) : (
-            <ChevronDown className="h-4 w-4" aria-hidden="true" />
-          )}
-        </CollapsibleTrigger>
-      </div>
-
-      <CollapsibleContent className="flex flex-col gap-3.5">
-        <div className="flex w-full gap-2.5">
-          <StatPill value={pendingCount} label="pendentes" />
-          <StatPill value={cartCount} label="comprados" />
-        </div>
-
-        {!category.isShared && (
-          <>
-            <div className="flex items-center gap-2.5">
-              <Button
-                variant="outline"
-                onClick={onOrganize}
-                disabled={isOrganizing || products.length < 2}
-                className="h-10 flex-1 border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] disabled:opacity-50 [&_svg]:size-4"
-              >
-                {isOrganizing ? <LoadingSpinner size={14} /> : <Sparkles aria-hidden="true" />}
-                Organizar lista
-              </Button>
-
-              {(category.subcategoryOrder?.length ?? 0) > 0 && (
-                <Button
-                  variant="outline"
-                  onClick={onRemoveGrouping}
-                  disabled={isRemovingGrouping}
-                  className="h-10 flex-1 border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] disabled:opacity-50 [&_svg]:size-4"
-                >
-                  {isRemovingGrouping ? <LoadingSpinner size={14} /> : <ListX aria-hidden="true" />}
-                  Remover agrupamento
-                </Button>
-              )}
+        {totalCount > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <div
+              className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--color-surface-card)]"
+              role="progressbar"
+              aria-valuenow={cartCount}
+              aria-valuemin={0}
+              aria-valuemax={totalCount}
+              aria-label={`${cartCount} de ${totalCount} ${totalCount === 1 ? 'item' : 'itens'} no carrinho`}
+            >
+              <div
+                className="h-full rounded-full bg-[var(--color-success)] transition-[width] duration-300 ease-out motion-reduce:transition-none"
+                style={{ width: `${cartPercent}%` }}
+              />
             </div>
 
-            <Button
-              variant="outline"
-              onClick={handleShare}
-              className="h-10 w-full border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] [&_svg]:size-4"
-            >
-              <Share2 aria-hidden="true" />
-              Compartilhar lista
-            </Button>
-          </>
+            <span className="text-[12px] text-[var(--color-muted)]">
+              <span className="font-semibold text-[var(--color-ink)]">
+                {cartCount} de {totalCount}
+              </span>{' '}
+              {totalCount === 1 ? 'item' : 'itens'} no carrinho
+            </span>
+          </div>
         )}
 
-        <div>
-          <CategorySelect />
-        </div>
-      </CollapsibleContent>
+        {!category.isShared && (
+          <CollapsibleTrigger
+            className="absolute right-0 top-0 flex h-9 w-9 items-center justify-center rounded-full border border-[var(--color-hairline)] bg-[var(--color-surface-soft)] text-[var(--color-ink)] transition-colors before:absolute before:-inset-1 before:rounded-full before:content-[''] hover:bg-[var(--color-surface-card)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ink)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-canvas)]"
+            aria-label={toggleLabel}
+          >
+            {isOpen ? (
+              <ChevronUp className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-4 w-4" aria-hidden="true" />
+            )}
+          </CollapsibleTrigger>
+        )}
+      </div>
+
+      {!category.isShared && (
+        <CollapsibleContent className="flex flex-col gap-3.5">
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center">
+            <Button
+              variant="outline"
+              onClick={onOrganize}
+              disabled={isOrganizing || products.length < 2}
+              className="h-10 w-full sm:flex-1 border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] focus-visible:ring-2 focus-visible:ring-[var(--color-ink)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-canvas)] disabled:opacity-50 [&_svg]:size-4"
+            >
+              {isOrganizing ? <LoadingSpinner size={14} /> : <Sparkles aria-hidden="true" />}
+              Organizar lista
+            </Button>
+
+            {(category.subcategoryOrder?.length ?? 0) > 0 && (
+              <Button
+                variant="outline"
+                onClick={onRemoveGrouping}
+                disabled={isRemovingGrouping}
+                className="h-10 w-full sm:flex-1 border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] focus-visible:ring-2 focus-visible:ring-[var(--color-ink)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-canvas)] disabled:opacity-50 [&_svg]:size-4"
+              >
+                {isRemovingGrouping ? <LoadingSpinner size={14} /> : <ListX aria-hidden="true" />}
+                Remover agrupamento
+              </Button>
+            )}
+          </div>
+
+          <Button
+            variant="outline"
+            onClick={handleShare}
+            className="h-10 w-full border-[var(--color-hairline)] bg-[var(--color-surface-card)] text-sm font-semibold text-[var(--color-ink)] shadow-none hover:bg-[var(--color-surface-soft)] hover:text-[var(--color-ink)] focus-visible:ring-2 focus-visible:ring-[var(--color-ink)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-canvas)] [&_svg]:size-4"
+          >
+            <Share2 aria-hidden="true" />
+            Compartilhar lista
+          </Button>
+        </CollapsibleContent>
+      )}
     </Collapsible>
   );
 }

--- a/src/components/category-select.tsx
+++ b/src/components/category-select.tsx
@@ -20,17 +20,13 @@ export function CategorySelect() {
 
   return (
     <Select value={selectedCategoryId || ''} onValueChange={handleCategoryChange}>
-      <SelectTrigger className="flex h-16 w-full items-center justify-between gap-2 rounded-[var(--radius-md)] border border-[var(--color-hairline)] bg-[var(--color-surface-card)] px-[14px] py-[13px] shadow-none [&>svg]:hidden">
-        <div className="flex min-w-0 flex-1 flex-col items-start gap-[3px]">
-          <span className="text-[10px] font-bold leading-none text-[var(--color-muted)]">
-            Lista atual
-          </span>
-          <span className="w-full truncate text-left text-[14px] font-semibold leading-[1.15] text-[var(--color-ink)]">
-            {selectedName}
-          </span>
-        </div>
+      <SelectTrigger
+        aria-label={`Lista atual: ${selectedName}. Trocar de lista`}
+        className="relative flex h-auto w-fit items-center gap-1 rounded-sm border-0 bg-transparent p-0 py-0.5 text-[12px] font-semibold leading-none text-[var(--color-ink)] shadow-none before:absolute before:-inset-x-1.5 before:-inset-y-2.5 before:content-[''] focus:ring-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-ink)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-canvas)] [&>svg]:hidden"
+      >
+        <span className="max-w-[55vw] truncate" aria-current="page">{selectedName}</span>
         <span className="flex shrink-0 items-center">
-          <ChevronDown className="h-[18px] w-[18px] text-[var(--color-ink)]" />
+          <ChevronDown className="h-3.5 w-3.5 text-[var(--color-muted)]" aria-hidden="true" />
         </span>
       </SelectTrigger>
 


### PR DESCRIPTION
Link do Jira https://goomer.atlassian.net/browse/SGMD-0002

## Contexto

O hero card da categoria acumulava informação e ações de forma pouco escaneável — dois stat pills, um badge de carrinho e as ações espremidas em botões-ícone — e a troca de lista ficava escondida dentro do conteúdo colapsável. Além disso, a organização automática por IA não tinha como ser revertida caso o resultado não agradasse. Este PR reorganiza o hero card, promove o seletor de lista para o breadcrumb e adiciona um caminho de desfazer para a organização.

## O que foi feito

- **Seletor de lista no breadcrumb**: o `CategorySelect` saiu do interior do hero card e passou a ocupar o lugar do nome estático no breadcrumb, virando um seletor inline compacto (texto + chevron) para trocar de lista sem abrir o card.
- **Barra de progresso do carrinho**: os stat pills e o badge "no carrinho" deram lugar a uma barra de progresso (`role="progressbar"` com `aria-valuenow/min/max`) mostrando `X de Y itens no carrinho`, com transição respeitando `prefers-reduced-motion`.
- **Ações reorganizadas**: "Organizar lista", "Remover agrupamento" e "Compartilhar" viraram botões com rótulo em layout responsivo (empilhados no mobile, lado a lado no desktop) e foco visível consistente, no lugar dos antigos botões-ícone.
- **Desfazer organização**: o toast de "Lista organizada!" agora traz a ação "Desfazer" (8s) que chama `DELETE /api/categories/:id/grouping` e reverte o agrupamento; o `categoryId` é capturado no disparo para não depender do estado atual.
- **Listas compartilhadas**: o trigger de colapso e o bloco de ações só aparecem quando a lista não é compartilhada (`!category.isShared`).
- **Higiene de repositório**: passa a ignorar artefatos de tooling (`.playwright-mcp/`, `.impeccable/critique/`, `.impeccable/design.json`, screenshots de crítica) que vinham sendo commitados por engano.

_Inclui também o commit SGMD-0001 (exibe rótulos nos botões de IA e reordena as ações da categoria)._