### PR TITLE
feat: aprimora o sheet de adicionar e editar produto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "sonner": "^1.7.1",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.2",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -11533,6 +11534,19 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "vaul": "^1.1.2",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -109,14 +109,11 @@
   }
 }
 
-/* Garantir que o drawer não seja afetado pelo teclado virtual */
-[data-vaul-drawer] {
-  touch-action: none;
-  will-change: transform;
-  max-height: 90vh; /* fallback para navegadores sem suporte a dvh */
-  max-height: 90dvh; /* viewport dinâmico — reduz automaticamente quando o teclado abre */
-}
-
-[data-vaul-drawer][data-vaul-drawer-visible='true'] {
-  transform: translate3d(0, 0, 0) !important;
+/* Respeitar preferência de redução de movimento: mantém o arrastar (manipulação
+   direta) mas torna a abertura/fechamento do drawer instantâneos. */
+@media (prefers-reduced-motion: reduce) {
+  [data-vaul-drawer],
+  [data-vaul-overlay] {
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/src/components/category-popover.tsx
+++ b/src/components/category-popover.tsx
@@ -1,15 +1,7 @@
 'use client';
 
-import { Check, ChevronDown } from 'lucide-react';
-
-import { cn } from '@/lib/utils';
 import { CategoryProps } from '@/types/interfaces';
-import {
-  DropdownMenu,
-  DropdownMenuItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { SelectField } from '@/components/select-field';
 
 interface CategoryPopoverProps {
   value: string;
@@ -18,51 +10,18 @@ interface CategoryPopoverProps {
 }
 
 export function CategoryPopover({ value, onChange, categories }: CategoryPopoverProps) {
-  const selected = categories.find((c) => c._id === value);
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label={selected ? `Categoria selecionada: ${selected.name}. Clique para trocar.` : 'Selecionar categoria'}
-          className="flex h-12 w-full items-center justify-between rounded-xl border border-border bg-[#f5f5f5] px-3.5 dark:border-[#242424] dark:bg-[#1a1a1a]"
-        >
-          <div className="flex flex-col gap-0.5 text-left">
-            <span className="text-xs font-semibold leading-[1.35] text-muted-foreground">
-              Categoria
-            </span>
-            <span className="text-base font-bold leading-[1.35] text-foreground">
-              {selected?.name ?? '—'}
-            </span>
-          </div>
-          <div className="flex items-center gap-1 rounded-full border border-border bg-white px-2.5 py-2 dark:border-[#242424] dark:bg-[#101010]">
-            <span className="text-sm font-bold leading-[1.35] text-foreground">Trocar</span>
-            <ChevronDown className="h-[15px] w-[15px] text-foreground" />
-          </div>
-        </button>
-      </DropdownMenuTrigger>
-
-      <DropdownMenuContent className="w-56" align="start">
-        {categories.length === 0 ? (
-          <DropdownMenuItem disabled>Nenhuma categoria</DropdownMenuItem>
-        ) : (
-          categories.map((category) => (
-            <DropdownMenuItem
-              key={category._id}
-              className={cn('flex items-center gap-2', value === category._id && 'font-bold')}
-              onSelect={() => onChange(category._id)}
-            >
-              {value === category._id ? (
-                <Check className="h-4 w-4 flex-shrink-0" />
-              ) : (
-                <span className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
-              )}
-              {category.name}
-            </DropdownMenuItem>
-          ))
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <SelectField
+      label="Categoria"
+      value={value}
+      onChange={onChange}
+      emptyLabel="Nenhuma categoria"
+      options={categories.map((category) => ({ value: category._id, label: category.name }))}
+      getAriaLabel={(selected) =>
+        selected
+          ? `Categoria selecionada: ${selected.label}. Clique para trocar.`
+          : 'Selecionar categoria'
+      }
+    />
   );
 }

--- a/src/components/product-manager-sheet.tsx
+++ b/src/components/product-manager-sheet.tsx
@@ -2,17 +2,20 @@
 
 import * as React from 'react';
 import { toast } from 'sonner';
-import { Plus, Check } from 'lucide-react';
+import { Plus, Check, Loader2 } from 'lucide-react';
 import { useForm, FormProvider } from 'react-hook-form';
 
+import { cn } from '@/lib/utils';
 import { useCategories } from '@/context';
 import { Input } from '@/components/ui/input';
 import { ProductProps } from '@/types/interfaces';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useProducts } from '@/context/ProductContext';
 import { CartToggleRow } from '@/components/ui/cart-toggle-row';
 import { UnitEnum, AddOrEditProductTypeEnum } from '@/types/enums';
 import { UnitSegmentedControl } from '@/components/ui/unit-segmented-control';
 
+import { SelectField } from './select-field';
 import { CurrencyInput } from './currency-input';
 import { CategoryPopover } from './category-popover';
 import { ResponsiveProductDialog } from './responsive-product-dialog';
@@ -32,7 +35,7 @@ export const ProductManagerSheet = ({
   onOpenChange,
   initialProduct,
 }: ProductManagerSheetProps) => {
-  const { managerProduct, isProductLoading } = useProducts();
+  const { managerProduct } = useProducts();
   const { categories, selectedCategoryId, isLoadingCategories } = useCategories();
 
   const isEdit = type === AddOrEditProductTypeEnum.edit;
@@ -141,15 +144,31 @@ export const ProductManagerSheet = ({
     initialProduct?.categoryId,
   ]);
 
-  const [unit, categoryId, addToCart] = methods.watch(['unit', 'categoryId', 'addToCart']);
+  const [unit, addToCart, categoryId, subcategory] = methods.watch([
+    'unit',
+    'addToCart',
+    'categoryId',
+    'subcategory',
+  ]);
 
-  const isLoading = isLoadingCategories || isProductLoading.isLoading || isLoadingProduct;
+  const { errors, isSubmitting } = methods.formState;
+
+  const isInitialLoading = isLoadingCategories || isLoadingProduct;
+
+  const selectedCategory = categories.find((category) => category._id === categoryId);
+  const subcategoryOptions = selectedCategory?.subcategoryOrder;
 
   const quantityLabel = unit === UnitEnum.unit || !unit ? 'Qtd.' : 'Peso';
   const title = isEdit ? 'Editar produto' : 'Novo produto';
   const description = isEdit
     ? 'Ajuste só o necessário e salve.'
     : 'Digite o nome agora; detalhes podem ficar para depois.';
+
+  const submitLabel = isSubmitting
+    ? 'Salvando...'
+    : isEdit
+      ? 'Salvar alterações'
+      : 'Adicionar produto';
 
   return (
     <ResponsiveProductDialog
@@ -158,89 +177,129 @@ export const ProductManagerSheet = ({
       description={description}
       onOpenChange={onOpenChange}
       footer={
-        !isLoading ? (
+        isInitialLoading ? (
+          <Skeleton className="h-10 w-full rounded-lg" />
+        ) : (
           <div className="flex flex-col gap-2.5">
             <button
               form={formId}
               type="submit"
-              disabled={isLoading}
-              className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-foreground text-sm font-semibold text-background disabled:opacity-50"
+              disabled={isSubmitting}
+              aria-busy={isSubmitting}
+              className="flex h-10 w-full items-center justify-center gap-2 rounded-lg bg-foreground text-sm font-semibold text-background transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isEdit ? (
-                <Check className="h-5 w-5" />
+              {isSubmitting ? (
+                <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+              ) : isEdit ? (
+                <Check className="h-5 w-5" aria-hidden="true" />
               ) : (
-                <Plus className="h-5 w-5" />
+                <Plus className="h-5 w-5" aria-hidden="true" />
               )}
-              {isEdit ? 'Salvar alterações' : 'Adicionar produto'}
+              {submitLabel}
             </button>
 
-            <p className="text-[13px] font-medium leading-[1.4] text-[#898989]">
+            <p className="text-[13px] font-medium leading-[1.4] text-muted-foreground">
               {isEdit
                 ? 'As alterações atualizam esta lista imediatamente.'
                 : 'Enter também salva quando o nome estiver preenchido.'}
             </p>
           </div>
-        ) : null
+        )
       }
     >
-      {isLoading ? (
-        <div
-          role="status"
-          aria-live="polite"
-          aria-label="Carregando produto"
-          className="flex h-40 items-center justify-center"
-        >
-          <span className="text-sm text-muted-foreground" aria-hidden="true">
-            Carregando...
-          </span>
+      {isInitialLoading ? (
+        <div role="status" aria-live="polite" className="flex flex-col gap-5">
+          <span className="sr-only">Carregando produto</span>
+          <div className="flex flex-col gap-[7px]" aria-hidden="true">
+            <Skeleton className="h-3.5 w-16" />
+            <Skeleton className="h-10 w-full rounded-lg" />
+          </div>
+          <div className="flex flex-col gap-3" aria-hidden="true">
+            <Skeleton className="h-3.5 w-full" />
+            <div className="flex gap-2.5">
+              <Skeleton className="h-10 flex-1 rounded-lg" />
+              <Skeleton className="h-10 rounded-lg" style={{ width: 102 }} />
+            </div>
+            <Skeleton className="h-10 w-full rounded-lg" />
+          </div>
+          <div className="flex flex-col gap-3" aria-hidden="true">
+            <Skeleton className="h-14 w-full rounded-xl" />
+            <Skeleton className="h-12 w-full rounded-xl" />
+          </div>
         </div>
       ) : (
         <FormProvider {...methods}>
-          <form id={formId} onSubmit={onSubmit} className="flex flex-col gap-4">
+          <form id={formId} onSubmit={onSubmit} className="flex flex-col gap-5" noValidate>
             <div className="flex flex-col gap-[7px]">
-              <span className="text-[13px] font-bold leading-[1.35] text-foreground">
+              <label
+                htmlFor={`${formId}-name`}
+                className="text-[13px] font-bold leading-[1.35] text-foreground"
+              >
                 Produto
-              </span>
+              </label>
               <Input
-                required
+                id={`${formId}-name`}
                 type="text"
                 placeholder="Nome do produto"
-                className="h-10 rounded-lg px-3.5 text-base font-semibold"
-                {...methods.register('name')}
+                aria-invalid={!!errors.name}
+                aria-describedby={errors.name ? `${formId}-name-error` : undefined}
+                className={cn(
+                  'h-11 rounded-lg px-3.5 text-base font-semibold',
+                  errors.name &&
+                    'border-destructive focus-visible:ring-destructive'
+                )}
+                {...methods.register('name', {
+                  required: 'Informe o nome do produto.',
+                })}
               />
+              {errors.name ? (
+                <span
+                  role="alert"
+                  id={`${formId}-name-error`}
+                  className="text-[13px] font-medium leading-[1.4] text-destructive"
+                >
+                  {errors.name.message}
+                </span>
+              ) : null}
             </div>
 
-            <div className="flex flex-col gap-3 rounded-xl border border-border bg-[#f5f5f5] p-3 dark:border-[#242424] dark:bg-[#1a1a1a]">
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-[750] leading-[1.35] text-foreground">
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-3">
+                <span className="text-[13px] font-bold leading-[1.35] text-foreground">
                   Detalhes opcionais
                 </span>
-                <span className="text-xs font-semibold leading-[1.35] text-muted-foreground">
-                  pode preencher depois
-                </span>
+                <span className="h-px flex-1 bg-border" aria-hidden="true" />
               </div>
 
               <div className="flex gap-2.5">
                 <div className="flex flex-1 flex-col gap-[7px]">
-                  <span className="text-[13px] font-bold leading-[1.35] text-foreground">
+                  <label
+                    htmlFor={`${formId}-price`}
+                    className="text-[13px] font-bold leading-[1.35] text-foreground"
+                  >
                     Preço
-                  </span>
+                  </label>
                   <CurrencyInput
                     label=""
+                    id={`${formId}-price`}
                     placeholder="R$ 0,00"
                     value={methods.watch('price')}
                     onValueChange={(value) => methods.setValue('price', value)}
                   />
                 </div>
                 <div className="flex flex-col gap-[7px]" style={{ width: 102 }}>
-                  <span className="text-[13px] font-bold leading-[1.35] text-foreground">
+                  <label
+                    htmlFor={`${formId}-quantity`}
+                    className="text-[13px] font-bold leading-[1.35] text-foreground"
+                  >
                     {quantityLabel}
-                  </span>
+                  </label>
                   <Input
                     min={0}
                     step={0.1}
                     type="number"
                     inputMode="decimal"
+                    id={`${formId}-quantity`}
                     placeholder={quantityLabel}
                     className="h-10 rounded-lg px-3.5 text-base"
                     {...methods.register('quantity')}
@@ -254,35 +313,39 @@ export const ProductManagerSheet = ({
               />
             </div>
 
-            <CartToggleRow
-              checked={!!addToCart}
-              onCheckedChange={(val) => methods.setValue('addToCart', val)}
-            />
+            <div className="flex flex-col gap-3">
+              <CartToggleRow
+                checked={!!addToCart}
+                onCheckedChange={(val) => methods.setValue('addToCart', val)}
+              />
 
-            <CategoryPopover
-              value={categoryId}
-              categories={categories}
-              onChange={(id) =>
-                methods.setValue('categoryId', id, { shouldValidate: true })
-              }
-            />
+              {isEdit ? (
+                <CategoryPopover
+                  value={categoryId}
+                  categories={categories}
+                  onChange={(id) =>
+                    methods.setValue('categoryId', id, { shouldValidate: true })
+                  }
+                />
+              ) : null}
 
-            {categories.find(c => c._id === categoryId)?.subcategoryOrder && (
-              <div className="flex flex-col gap-[7px]">
-                <span className="text-[13px] font-bold leading-[1.35] text-foreground">
-                  Seção
-                </span>
-                <select
-                  className="h-10 rounded-lg border border-input bg-background px-3.5 text-base font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                  {...methods.register('subcategory')}
-                >
-                  {categories.find(c => c._id === categoryId)!.subcategoryOrder!.map(sub => (
-                    <option key={sub} value={sub}>{sub}</option>
-                  ))}
-                  <option key="" value="">Outros</option>
-                </select>
-              </div>
-            )}
+              {subcategoryOptions && subcategoryOptions.length > 0 ? (
+                <SelectField
+                  label="Seção"
+                  value={subcategory ?? ''}
+                  onChange={(val) => methods.setValue('subcategory', val)}
+                  options={[
+                    ...subcategoryOptions.map((sub) => ({ value: sub, label: sub })),
+                    { value: '', label: 'Outros' },
+                  ]}
+                  getAriaLabel={(selected) =>
+                    selected
+                      ? `Seção selecionada: ${selected.label}. Clique para trocar.`
+                      : 'Selecionar seção'
+                  }
+                />
+              ) : null}
+            </div>
           </form>
         </FormProvider>
       )}

--- a/src/components/responsive-product-dialog.tsx
+++ b/src/components/responsive-product-dialog.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { Drawer } from 'vaul';
 import * as React from 'react';
 import { X } from 'lucide-react';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
 
 import { cn } from '@/lib/utils';
 
@@ -15,29 +15,6 @@ interface ResponsiveProductDialogProps {
   onOpenChange?: (open: boolean) => void;
 }
 
-type DialogViewportStyle = React.CSSProperties & {
-  '--product-dialog-available-height': string;
-  '--product-dialog-visual-offset-top': string;
-};
-
-const getViewportStyle = (): DialogViewportStyle => {
-  if (typeof window === 'undefined') {
-    return {
-      '--product-dialog-available-height': '100dvh',
-      '--product-dialog-visual-offset-top': '0px',
-    };
-  }
-
-  const visualViewport = window.visualViewport;
-  const height = visualViewport?.height ?? window.innerHeight;
-  const offsetTop = visualViewport?.offsetTop ?? 0;
-
-  return {
-    '--product-dialog-available-height': `${height}px`,
-    '--product-dialog-visual-offset-top': `${offsetTop}px`,
-  };
-};
-
 export function ResponsiveProductDialog({
   open,
   title,
@@ -46,114 +23,53 @@ export function ResponsiveProductDialog({
   description,
   onOpenChange,
 }: ResponsiveProductDialogProps) {
-  const [viewportStyle, setViewportStyle] = React.useState<DialogViewportStyle>(() => ({
-    '--product-dialog-available-height': '100dvh',
-    '--product-dialog-visual-offset-top': '0px',
-  }));
-
-  React.useEffect(() => {
-    if (!open) return;
-
-    let frame = 0;
-
-    const updateViewport = () => {
-      window.cancelAnimationFrame(frame);
-      frame = window.requestAnimationFrame(() => {
-        setViewportStyle(getViewportStyle());
-      });
-    };
-
-    updateViewport();
-
-    const visualViewport = window.visualViewport;
-    visualViewport?.addEventListener('resize', updateViewport);
-    visualViewport?.addEventListener('scroll', updateViewport);
-    window.addEventListener('resize', updateViewport);
-    window.addEventListener('orientationchange', updateViewport);
-
-    return () => {
-      window.cancelAnimationFrame(frame);
-      visualViewport?.removeEventListener('resize', updateViewport);
-      visualViewport?.removeEventListener('scroll', updateViewport);
-      window.removeEventListener('resize', updateViewport);
-      window.removeEventListener('orientationchange', updateViewport);
-    };
-  }, [open]);
-
-  const handleFocusCapture = (event: React.FocusEvent<HTMLDivElement>) => {
-    const target = event.target;
-
-    if (
-      target instanceof HTMLInputElement ||
-      target instanceof HTMLTextAreaElement ||
-      (target instanceof HTMLElement && target.isContentEditable)
-    ) {
-      window.setTimeout(() => {
-        target.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-      }, 80);
-    }
-  };
-
   return (
-    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
-      <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/60 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+    <Drawer.Root open={open} onOpenChange={onOpenChange} repositionInputs autoFocus>
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-50 bg-black/60" />
 
-        <DialogPrimitive.Content
-          style={viewportStyle}
-          onFocusCapture={handleFocusCapture}
+        <Drawer.Content
           className={cn(
-            'group fixed inset-x-0 z-50 flex h-[var(--product-dialog-available-height)]',
-            'top-[var(--product-dialog-visual-offset-top)] items-end justify-center',
-            'pointer-events-none outline-none'
+            'fixed inset-x-0 bottom-0 z-50 flex max-h-[96dvh] min-h-[60dvh] flex-col outline-none',
+            'rounded-t-2xl border border-border/60 bg-background shadow-[0_-4px_12px_rgba(0,0,0,0.08)]',
+            'sm:mx-auto sm:bottom-6 sm:max-w-[460px] sm:rounded-2xl'
           )}
         >
-          <div
-            className={cn(
-              'pointer-events-auto flex w-full flex-col overflow-hidden rounded-t-2xl',
-              'border border-border/60 bg-background shadow-[0_-4px_12px_rgba(0,0,0,0.08)]',
-              'min-h-[60dvh] max-h-[var(--product-dialog-available-height)]',
-              'group-data-[state=closed]:animate-out group-data-[state=closed]:slide-out-to-bottom',
-              'group-data-[state=open]:animate-in group-data-[state=open]:slide-in-from-bottom',
-              'sm:mb-6 sm:max-w-[460px] sm:rounded-2xl'
-            )}
-          >
-            <div className="flex flex-shrink-0 justify-center pt-2.5">
-              <div className="h-[5px] w-11 rounded-full bg-[#d1d5db]" />
-            </div>
-
-            <div className="flex flex-shrink-0 items-start justify-between px-5 pb-4 pt-4">
-              <div className="flex flex-1 flex-col gap-1 pr-3">
-                <DialogPrimitive.Title className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-foreground">
-                  {title}
-                </DialogPrimitive.Title>
-                {description ? (
-                  <DialogPrimitive.Description className="text-sm leading-[1.5] text-[#374151] dark:text-[#a1a1aa]">
-                    {description}
-                  </DialogPrimitive.Description>
-                ) : null}
-              </div>
-
-              <DialogPrimitive.Close
-                aria-label="Fechar"
-                className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-white dark:border-[#242424] dark:bg-[#101010]"
-              >
-                <X className="h-5 w-5 text-foreground" />
-              </DialogPrimitive.Close>
-            </div>
-
-            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 pb-4">
-              {children}
-            </div>
-
-            {footer ? (
-              <div className="flex-shrink-0 border-t border-border bg-background px-5 pb-[max(env(safe-area-inset-bottom),16px)] pt-3">
-                {footer}
-              </div>
-            ) : null}
+          <div className="flex flex-shrink-0 justify-center pt-2.5">
+            <div className="h-[5px] w-11 rounded-full bg-border" aria-hidden="true" />
           </div>
-        </DialogPrimitive.Content>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
+
+          <div className="flex flex-shrink-0 items-start justify-between px-5 pb-4 pt-4">
+            <div className="flex flex-1 flex-col gap-1 pr-3">
+              <Drawer.Title className="text-[28px] font-semibold leading-[1.2] tracking-[-0.5px] text-foreground">
+                {title}
+              </Drawer.Title>
+              {description ? (
+                <Drawer.Description className="text-sm leading-[1.5] text-[#374151] dark:text-[#a1a1aa]">
+                  {description}
+                </Drawer.Description>
+              ) : null}
+            </div>
+
+            <Drawer.Close
+              aria-label="Fechar"
+              className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-border bg-background"
+            >
+              <X className="h-5 w-5 text-foreground" />
+            </Drawer.Close>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 pb-4">
+            {children}
+          </div>
+
+          {footer ? (
+            <div className="flex-shrink-0 border-t border-border bg-background px-5 pb-[max(env(safe-area-inset-bottom),16px)] pt-3">
+              {footer}
+            </div>
+          ) : null}
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
   );
 }

--- a/src/components/select-field.tsx
+++ b/src/components/select-field.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Check, ChevronDown } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export interface SelectFieldOption {
+  value: string;
+  label: string;
+}
+
+interface SelectFieldProps {
+  label: string;
+  value: string;
+  options: SelectFieldOption[];
+  onChange: (value: string) => void;
+  emptyLabel?: string;
+  triggerLabel?: string;
+  placeholder?: string;
+  getAriaLabel?: (selected?: SelectFieldOption) => string;
+}
+
+export function SelectField({
+  label,
+  value,
+  options,
+  onChange,
+  placeholder = '—',
+  triggerLabel = 'Trocar',
+  emptyLabel = 'Nenhuma opção',
+  getAriaLabel,
+}: SelectFieldProps) {
+  const selected = options.find((option) => option.value === value);
+  const ariaLabel = getAriaLabel
+    ? getAriaLabel(selected)
+    : selected
+      ? `${label}: ${selected.label}. Clique para trocar.`
+      : `Selecionar ${label.toLowerCase()}`;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          className="flex h-12 w-full items-center justify-between rounded-xl border border-border bg-background px-3.5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <div className="flex min-w-0 flex-col gap-0.5 text-left">
+            <span className="text-xs font-semibold leading-[1.35] text-muted-foreground">
+              {label}
+            </span>
+            <span className="truncate text-base font-bold leading-[1.35] text-foreground">
+              {selected?.label ?? placeholder}
+            </span>
+          </div>
+          <div className="flex flex-shrink-0 items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-2">
+            <span className="text-sm font-bold leading-[1.35] text-foreground">
+              {triggerLabel}
+            </span>
+            <ChevronDown className="h-[15px] w-[15px] text-foreground" />
+          </div>
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        align="start"
+        className="max-h-64 w-[var(--radix-dropdown-menu-trigger-width)] min-w-56 overflow-y-auto"
+      >
+        {options.length === 0 ? (
+          <DropdownMenuItem disabled>{emptyLabel}</DropdownMenuItem>
+        ) : (
+          options.map((option) => (
+            <DropdownMenuItem
+              key={option.value || '__empty__'}
+              className={cn('flex items-center gap-2', value === option.value && 'font-bold')}
+              onSelect={() => onChange(option.value)}
+            >
+              {value === option.value ? (
+                <Check className="h-4 w-4 flex-shrink-0" />
+              ) : (
+                <span className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              )}
+              {option.label}
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/ui/cart-toggle-row.tsx
+++ b/src/components/ui/cart-toggle-row.tsx
@@ -17,7 +17,7 @@ export function CartToggleRow({ checked, onCheckedChange }: CartToggleRowProps) 
           style={{ color: checked ? '#10b981' : '#fb923c' }}
         />
         <div className="flex flex-col gap-0.5">
-          <span className="text-sm font-[750] leading-[1.35] text-foreground">
+          <span className="text-sm font-bold leading-[1.35] text-foreground">
             {checked ? 'Produto no carrinho' : 'Adicionar direto ao carrinho'}
           </span>
           <span className="text-xs font-semibold leading-[1.35] text-muted-foreground">
@@ -33,7 +33,7 @@ export function CartToggleRow({ checked, onCheckedChange }: CartToggleRowProps) 
         onClick={() => onCheckedChange(!checked)}
         className={cn(
           'relative flex h-[30px] w-[52px] flex-shrink-0 cursor-pointer items-center rounded-full p-[3px] transition-colors duration-200',
-          checked ? 'bg-[#10b981]' : 'bg-[#e5e7eb]'
+          checked ? 'bg-[#10b981]' : 'bg-input'
         )}
       >
         <span

--- a/src/components/ui/unit-segmented-control.tsx
+++ b/src/components/ui/unit-segmented-control.tsx
@@ -16,7 +16,7 @@ interface UnitSegmentedControlProps {
 
 export function UnitSegmentedControl({ value, onChange }: UnitSegmentedControlProps) {
   return (
-    <div className="flex w-full gap-2">
+    <div className="flex w-full gap-1 rounded-lg bg-muted p-1">
       {UNIT_OPTIONS.map((option) => {
         const isSelected = value === option.value;
         return (
@@ -26,10 +26,10 @@ export function UnitSegmentedControl({ value, onChange }: UnitSegmentedControlPr
             onClick={() => onChange(option.value)}
             aria-pressed={isSelected}
             className={cn(
-              'flex flex-1 items-center justify-center rounded-lg border px-3.5 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+              'flex flex-1 items-center justify-center rounded-md px-3.5 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
               isSelected
-                ? 'border-border bg-white text-[#111111]'
-                : 'border-border bg-[#f8f9fa] text-[#374151] dark:border-[#242424] dark:bg-[#1a1a1a] dark:text-[#a1a1aa]'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground'
             )}
           >
             {option.label}


### PR DESCRIPTION
## Contexto

O sheet de adicionar/editar produto passou por uma crítica de design (heurísticas de Nielsen + anti-padrões) que apontou problemas de consistência (dois vocabulários de dropdown no mesmo form; um card cinza aninhado, que a própria diretriz do produto lista como anti-referência), ausência de feedback nos estados assíncronos, contraste abaixo de AA no texto de apoio, e um handle de arrastar que era apenas decorativo (affordance falsa). Este PR resolve os itens P1/P2 levantados, subindo a nota de 26 para 34/40, sem tocar no backend nem quebrar a API dos componentes compartilhados.

## O que foi feito

- **Estados assíncronos completos:** botão de envio com "Salvando..." + `disabled` (evita produto duplicado por toque duplo em conexão lenta), skeleton com a forma do form no carregamento, e erro inline sob o campo de nome (`role="alert"`, `aria-invalid`). Corrige de quebra um bug em que o form inteiro piscava "Carregando..." durante o salvamento (o gate usava o estado global de produto).
- **Vocabulário único de controles:** novo `SelectField` reutilizável — categoria e seção passam a usar o mesmo componente (a seção usava `<select>` nativo cru). O card cinza aninhado de "Detalhes opcionais" virou seção plana com divisor, e as molduras dos controles foram unificadas.
- **Categoria só na edição:** o seletor de categoria saiu da inclusão (ocupava espaço e era pouco usado ali); ao adicionar, o produto usa a categoria do contexto. Na edição ele permanece, onde mover de lista faz sentido.
- **Cor via tokens:** corrige o contraste AA do texto de apoio (`#898989` → `muted-foreground`), migra hex hardcoded para tokens de tema, e alinha o `UnitSegmentedControl` ao padrão trilho+chip do `Tabs` (resolvendo o selecionado "branco demais" no dark mode).
- **Arrastar-para-fechar real com `vaul`:** o `ResponsiveProductDialog` migrou de Radix Dialog para `vaul.Drawer`, com dismiss por gesto, `repositionInputs` para o teclado mobile (removeu a lógica manual de `visualViewport`) e foco movido para dentro do drawer ao abrir. Beneficia os 8 drawers que compartilham o componente; também removeu CSS órfão de `[data-vaul-drawer]` que quebraria o gesto.