### PR TITLE
fix(drawer): disable vaul repositionInputs and control keyboard viewport manually

### DIFF
--- a/src/components/responsive-product-dialog.tsx
+++ b/src/components/responsive-product-dialog.tsx
@@ -15,6 +15,22 @@ interface ResponsiveProductDialogProps {
   onOpenChange?: (open: boolean) => void;
 }
 
+interface KeyboardViewportOverride {
+  bottom: number;
+  maxHeight: number;
+}
+
+const getKeyboardViewportOverride = (): KeyboardViewportOverride | null => {
+  if (typeof window === 'undefined' || !window.visualViewport) return null;
+
+  const { height, offsetTop } = window.visualViewport;
+  const bottom = Math.max(0, Math.round(window.innerHeight - height - offsetTop));
+
+  if (bottom === 0) return null;
+
+  return { bottom, maxHeight: Math.round(height) };
+};
+
 export function ResponsiveProductDialog({
   open,
   title,
@@ -23,12 +39,52 @@ export function ResponsiveProductDialog({
   description,
   onOpenChange,
 }: ResponsiveProductDialogProps) {
+  const [keyboardOverride, setKeyboardOverride] = React.useState<KeyboardViewportOverride | null>(
+    null
+  );
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    let frame = 0;
+    const visualViewport = window.visualViewport;
+
+    const updateOverride = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        setKeyboardOverride(getKeyboardViewportOverride());
+      });
+    };
+
+    updateOverride();
+    visualViewport?.addEventListener('resize', updateOverride);
+    visualViewport?.addEventListener('scroll', updateOverride);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      setKeyboardOverride(null);
+      visualViewport?.removeEventListener('resize', updateOverride);
+      visualViewport?.removeEventListener('scroll', updateOverride);
+    };
+  }, [open]);
+
+  let contentStyle: React.CSSProperties | undefined;
+
+  if (keyboardOverride) {
+    contentStyle = {
+      minHeight: 0,
+      bottom: keyboardOverride.bottom,
+      maxHeight: keyboardOverride.maxHeight,
+    };
+  }
+
   return (
-    <Drawer.Root open={open} onOpenChange={onOpenChange} repositionInputs autoFocus>
+    <Drawer.Root open={open} onOpenChange={onOpenChange} repositionInputs={false} autoFocus>
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 z-50 bg-black/60" />
 
         <Drawer.Content
+          style={contentStyle}
           className={cn(
             'fixed inset-x-0 bottom-0 z-50 flex max-h-[96dvh] min-h-[60dvh] flex-col outline-none',
             'rounded-t-2xl border border-border/60 bg-background shadow-[0_-4px_12px_rgba(0,0,0,0.08)]',


### PR DESCRIPTION
## Contexto

O sheet de produto/categoria (`ResponsiveProductDialog`) é ancorado com `position: fixed` + `bottom-0`, que no iOS Safari fica preso ao layout viewport em vez do visual viewport quando o teclado abre. O PR #108 tinha reativado `repositionInputs` do Vaul para compensar isso via arrastar-para-fechar, mas esse é exatamente o mecanismo que já tinha causado esse bug antes: o Vaul escreve `style.height`/`style.bottom` no `Drawer.Content` a partir de `visualViewport.resize`, e essa heurística é reconhecidamente instável entre iOS Safari, Chrome iOS e Android (o motivo pelo qual o modal já tinha sido migrado para longe de Vaul em junho, migração que a PR #108 reverteu sem saber do histórico). O sintoma era o sheet cortado no topo com um gap vazio acima do teclado.

## O que foi feito

- `repositionInputs={false}` no `Drawer.Root` — desliga a heurística quebrada do Vaul, mantendo o `Drawer.Root` (preserva o swipe-to-close que a PR #108 queria).
- Novo controle manual de viewport: escuta `visualViewport.resize`/`scroll` enquanto o sheet está aberto e só aplica `bottom`/`maxHeight`/`minHeight: 0` inline no `Drawer.Content` quando o teclado realmente reduz a área visível — ancorando o sheet à área visível real em vez de deixar o `bottom-0` fixo atrás do teclado.
- Quando não há teclado ativo, nada muda: as classes Tailwind (`max-h-[96dvh]`, `sm:bottom-6`, etc.) continuam valendo normalmente para desktop/tablet.
- Correção feita no componente compartilhado, então cobre automaticamente todos os drawers que o usam (produto, categoria, IA, confirmações).