### PR TITLE
feat(sticky-footer): colapsa o footer em FAB compacto durante o scroll

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "easy-list-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ next-env.d.ts
 .impeccable/critique/
 .impeccable/design.json
 /hero-critique-*.png
+
+# scratch de brainstorm/execucao assistida (mockups, ledgers, review packages)
+.superpowers/

--- a/docs/superpowers/plans/2026-07-31-sticky-footer-compact-fab.md
+++ b/docs/superpowers/plans/2026-07-31-sticky-footer-compact-fab.md
@@ -29,6 +29,7 @@
 | `src/hooks/useScrollDirection.ts` | **Criar.** Única responsabilidade: observar o scroll de `window` e expor direção + proximidade do fim do documento. Nenhum conhecimento de footer, produtos ou UI. |
 | `src/components/sticky-footer.tsx` | **Modificar.** Deriva o estado visual do hook, exporta `FOOTER_CLEARANCE_PX`, renderiza as duas camadas (card + FAB). |
 | `src/app/category/category-client.tsx` | **Modificar (1 linha + 1 import).** Consome `FOOTER_CLEARANCE_PX` para o espaço reservado na base da lista. |
+| `src/components/category-page-skeleton.tsx` | **Modificar (1 linha + 1 import).** Tem o mesmo container `flex flex-col gap-4 pb-[140px]` reservando espaço para o mesmo footer, então consome a mesma constante. |
 
 A fronteira importante: o hook não sabe nada sobre o footer, e o footer não fala com `window` diretamente. Isso mantém o hook reutilizável e o footer testável a olho.
 
@@ -364,6 +365,8 @@ git grep -n "140px" -- src/
 ```
 
 Esperado: nenhuma saída. Se aparecer alguma ocorrência, ela é um resquício do valor mágico antigo e deve passar a usar `FOOTER_CLEARANCE_PX`.
+
+Sabe-se que `src/components/category-page-skeleton.tsx` tem uma ocorrência: o skeleton da mesma página usa o container idêntico (`flex flex-col gap-4 pb-[140px]`) reservando espaço para o mesmo footer. Aplique nele a mesma troca (import + `style={{ paddingBottom: FOOTER_CLEARANCE_PX }}`).
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-07-31-sticky-footer-compact-fab.md
+++ b/docs/superpowers/plans/2026-07-31-sticky-footer-compact-fab.md
@@ -46,7 +46,7 @@ Crie `src/hooks/useScrollDirection.ts` com exatamente este conteúdo:
 ```ts
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 interface UseScrollDirectionOptions {
   threshold?: number;
@@ -62,8 +62,9 @@ export function useScrollDirection({
   threshold = 15,
   bottomOffset = 0,
 }: UseScrollDirectionOptions = {}): UseScrollDirectionResult {
-  const tickingRef = useRef(false);
   const lastScrollYRef = useRef(0);
+  const tickingRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
 
   const [isNearBottom, setIsNearBottom] = useState(true);
   const [isScrollingDown, setIsScrollingDown] = useState(false);
@@ -90,7 +91,7 @@ export function useScrollDirection({
 
       tickingRef.current = true;
 
-      window.requestAnimationFrame(() => {
+      rafIdRef.current = window.requestAnimationFrame(() => {
         measure();
         tickingRef.current = false;
       });
@@ -102,6 +103,9 @@ export function useScrollDirection({
     window.addEventListener('scroll', handleScroll, { passive: true });
 
     return () => {
+      if (rafIdRef.current !== null) {
+        window.cancelAnimationFrame(rafIdRef.current);
+      }
       window.removeEventListener('scroll', handleScroll);
       tickingRef.current = false;
     };
@@ -117,6 +121,9 @@ export function useScrollDirection({
 - `lastScrollYRef` só é atualizado **dentro** do `if` do threshold. Isso é intencional: scrolls pequenos e sucessivos na mesma direção acumulam até cruzar o limite, em vez de serem descartados um a um.
 - `setIsNearBottom` é chamado em todo tick (fora do `if` do threshold) porque atingir o fim da página precisa ser detectado mesmo em movimentos pequenos.
 - `tickingRef.current = false` no cleanup evita que um `rAF` já agendado deixe a flag travada em `true` caso o componente remonte.
+- O cleanup também chama `cancelAnimationFrame` no id guardado em `rafIdRef`: sem isso, um frame agendado imediatamente antes do unmount ainda executaria `measure()` e chamaria `setState` num componente desmontado.
+
+**Ordenação das declarações:** `.claude/rules/organization.md` ordena pela contagem de caracteres da **linha completa** (não do nome da variável), com empate resolvido alfabeticamente. Aqui: `const lastScrollYRef = useRef(0);` (33) e `const tickingRef = useRef(false);` (33) empatam → alfabética; `const rafIdRef = useRef<number | null>(null);` (45) vai por último. Para imports essa regra é **machine-enforced** por `eslint-plugin-perfectionist` (`sort-imports` e `sort-named-imports` com `type: line-length, order: asc`) — em caso de dúvida, rode `npx eslint --fix <arquivo>` e deixe o plugin posicionar.
 
 - [ ] **Step 2: Verificar tipos e lint**
 

--- a/docs/superpowers/plans/2026-07-31-sticky-footer-compact-fab.md
+++ b/docs/superpowers/plans/2026-07-31-sticky-footer-compact-fab.md
@@ -1,0 +1,431 @@
+# StickyFooter Expandido ↔ Compacto (FAB) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Colapsar o `StickyFooter` da página de categoria em um FAB pill compacto durante o scroll para baixo, reexpandindo no scroll para cima, no toque do FAB, ou ao atingir o fim da lista.
+
+**Architecture:** Um hook `useScrollDirection` isolado monitora o scroll de `window` com listener passivo coalescido por `requestAnimationFrame`, expondo `isScrollingDown` e `isNearBottom`. O `StickyFooter` deriva `isCompact` desses sinais mais um override local `forceExpanded`, e renderiza duas camadas irmãs (card expandido + FAB pill) que fazem cross-fade via classes Tailwind de `transform`/`opacity`. Sem lib de animação nova.
+
+**Tech Stack:** Next.js 15 (App Router), React 19, TypeScript strict, Tailwind CSS, `lucide-react`, `cn` de `@/lib/utils`.
+
+**Spec:** [docs/superpowers/specs/2026-07-31-sticky-footer-compact-fab-design.md](../specs/2026-07-31-sticky-footer-compact-fab-design.md)
+
+---
+
+## Contexto para quem não conhece o projeto
+
+- **Não existe suíte de testes.** Não há jest, vitest, testing-library nem qualquer arquivo `*.test.*` / `*.spec.*` no repositório. Não invente uma suíte: a verificação de cada task é `npm run lint` + `npx tsc --noEmit`, e a validação funcional é manual no browser (Task 4).
+- **Convenção de ordenação obrigatória** (`.claude/rules/organization.md`): imports, propriedades de objeto, campos de type e parâmetros multiline são ordenados por **menor quantidade de caracteres na linha completa primeiro**; empate resolve em ordem alfabética. Isso vale para todo código escrito neste plano — o código nos steps abaixo já está ordenado corretamente, copie como está.
+- **Tokens de design:** cores e raios vêm de CSS custom properties (`var(--color-primary)`, `var(--color-on-primary)`, `var(--radius-md)`, `var(--color-ink)`, `var(--color-muted)`, `var(--color-canvas)`, `var(--color-hairline)`, `var(--color-surface-card)`). Nunca use cores literais (`#18181b`, `bg-zinc-900`) — o hook de design do projeto reclama.
+- **O scroll é da janela** (`window`), não de um container. A lista não tem `overflow-y`.
+- **Servidor de dev:** use a ferramenta de preview do harness com a config `easy-list-dev` (já existe em `.claude/launch.json`, porta 3000). Nunca rode `npm run dev` via Bash.
+
+---
+
+## File Structure
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `src/hooks/useScrollDirection.ts` | **Criar.** Única responsabilidade: observar o scroll de `window` e expor direção + proximidade do fim do documento. Nenhum conhecimento de footer, produtos ou UI. |
+| `src/components/sticky-footer.tsx` | **Modificar.** Deriva o estado visual do hook, exporta `FOOTER_CLEARANCE_PX`, renderiza as duas camadas (card + FAB). |
+| `src/app/category/category-client.tsx` | **Modificar (1 linha + 1 import).** Consome `FOOTER_CLEARANCE_PX` para o espaço reservado na base da lista. |
+
+A fronteira importante: o hook não sabe nada sobre o footer, e o footer não fala com `window` diretamente. Isso mantém o hook reutilizável e o footer testável a olho.
+
+---
+
+## Task 1: Hook `useScrollDirection`
+
+**Files:**
+- Create: `src/hooks/useScrollDirection.ts`
+
+- [ ] **Step 1: Criar o arquivo do hook**
+
+Crie `src/hooks/useScrollDirection.ts` com exatamente este conteúdo:
+
+```ts
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+interface UseScrollDirectionOptions {
+  threshold?: number;
+  bottomOffset?: number;
+}
+
+interface UseScrollDirectionResult {
+  isNearBottom: boolean;
+  isScrollingDown: boolean;
+}
+
+export function useScrollDirection({
+  threshold = 15,
+  bottomOffset = 0,
+}: UseScrollDirectionOptions = {}): UseScrollDirectionResult {
+  const tickingRef = useRef(false);
+  const lastScrollYRef = useRef(0);
+
+  const [isNearBottom, setIsNearBottom] = useState(true);
+  const [isScrollingDown, setIsScrollingDown] = useState(false);
+
+  useEffect(() => {
+    function measure() {
+      const scrollY = window.scrollY;
+      const reachedBottom =
+        scrollY + window.innerHeight >=
+        document.documentElement.scrollHeight - bottomOffset;
+
+      setIsNearBottom(reachedBottom);
+
+      const delta = scrollY - lastScrollYRef.current;
+
+      if (Math.abs(delta) > threshold) {
+        setIsScrollingDown(delta > 0);
+        lastScrollYRef.current = scrollY;
+      }
+    }
+
+    function handleScroll() {
+      if (tickingRef.current) return;
+
+      tickingRef.current = true;
+
+      window.requestAnimationFrame(() => {
+        measure();
+        tickingRef.current = false;
+      });
+    }
+
+    lastScrollYRef.current = window.scrollY;
+    measure();
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      tickingRef.current = false;
+    };
+  }, [threshold, bottomOffset]);
+
+  return { isNearBottom, isScrollingDown };
+}
+```
+
+**Notas sobre decisões que parecem arbitrárias mas não são:**
+- `isNearBottom` inicia em `true` e `isScrollingDown` em `false` porque o estado inicial correto é **expandido**. Um valor inicial errado causaria um flash do FAB no primeiro paint.
+- `measure()` roda uma vez no mount porque o browser pode restaurar a posição de scroll ao voltar para a página — sem isso, o footer abriria expandido no meio da lista quando deveria já estar compacto.
+- `lastScrollYRef` só é atualizado **dentro** do `if` do threshold. Isso é intencional: scrolls pequenos e sucessivos na mesma direção acumulam até cruzar o limite, em vez de serem descartados um a um.
+- `setIsNearBottom` é chamado em todo tick (fora do `if` do threshold) porque atingir o fim da página precisa ser detectado mesmo em movimentos pequenos.
+- `tickingRef.current = false` no cleanup evita que um `rAF` já agendado deixe a flag travada em `true` caso o componente remonte.
+
+- [ ] **Step 2: Verificar tipos e lint**
+
+Rode:
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: nenhum erro. Depois:
+
+```bash
+npm run lint
+```
+
+Esperado: `✔ No ESLint warnings or errors`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useScrollDirection.ts
+git commit -m "feat(hooks): adiciona useScrollDirection com deteccao de direcao e fim de pagina"
+```
+
+---
+
+## Task 2: Refatorar `StickyFooter` com estado compacto
+
+**Files:**
+- Modify: `src/components/sticky-footer.tsx` (substituição integral do arquivo)
+
+- [ ] **Step 1: Substituir o conteúdo de `src/components/sticky-footer.tsx`**
+
+Substitua **todo** o arquivo por este conteúdo:
+
+```tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Plus, ScanLine } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { ProductProps } from '@/types/interfaces';
+import { useScrollDirection } from '@/hooks/useScrollDirection';
+import { convertToCurrency, calculateTotalValue } from '@/utils';
+
+export const FOOTER_CLEARANCE_PX = 140;
+
+interface StickyFooterProps {
+  products: ProductProps[];
+  onAddProduct: () => void;
+  onScanProduct: () => void;
+}
+
+export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFooterProps) {
+  const { isNearBottom, isScrollingDown } = useScrollDirection({
+    bottomOffset: FOOTER_CLEARANCE_PX,
+  });
+
+  const [forceExpanded, setForceExpanded] = useState(false);
+
+  const { totalProductsValue, filteredProductsValue } =
+    calculateTotalValue(products);
+
+  useEffect(() => {
+    if (isScrollingDown) setForceExpanded(false);
+  }, [isScrollingDown]);
+
+  const isCompact = isScrollingDown && !isNearBottom && !forceExpanded;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-10 pointer-events-none">
+      <div className="relative mx-auto max-w-3xl p-3">
+        <div
+          aria-hidden={isCompact}
+          className={cn(
+            'flex flex-col gap-3 rounded-[var(--radius-xl)] bg-[var(--color-canvas)] border border-[var(--color-hairline)] p-3 origin-bottom transition-all duration-200 ease-out motion-reduce:transition-none',
+            isCompact
+              ? 'pointer-events-none translate-y-2 scale-95 opacity-0'
+              : 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+          )}
+        >
+          {/* Totals row */}
+          <div className="flex items-center justify-between w-full">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-[12px] font-semibold text-[var(--color-muted)]">
+                Total
+              </span>
+              <span className="text-[12px] font-medium text-[var(--color-muted)]">
+                Carrinho: {convertToCurrency(filteredProductsValue)}
+              </span>
+            </div>
+            <span className="text-[22px] font-semibold text-[var(--color-ink)]">
+              {convertToCurrency(totalProductsValue)}
+            </span>
+          </div>
+
+          <div className="grid grid-cols-[1fr_48px] gap-2">
+            <button
+              type="button"
+              tabIndex={isCompact ? -1 : 0}
+              onClick={(e) => {
+                (e.currentTarget as HTMLButtonElement).blur();
+                onAddProduct();
+              }}
+              className="flex h-12 items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)]"
+            >
+              <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
+              <span className="text-[14px] font-semibold text-[var(--color-on-primary)]">
+                Adicionar produto
+              </span>
+            </button>
+
+            <button
+              type="button"
+              aria-label="Escanear produto"
+              tabIndex={isCompact ? -1 : 0}
+              onClick={(e) => {
+                (e.currentTarget as HTMLButtonElement).blur();
+                onScanProduct();
+              }}
+              className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-surface-card)]"
+            >
+              <ScanLine className="h-[15px] w-[15px] text-[var(--color-ink)]" />
+            </button>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          aria-hidden={!isCompact}
+          tabIndex={isCompact ? 0 : -1}
+          onClick={() => setForceExpanded(true)}
+          aria-label="Expandir resumo do carrinho"
+          className={cn(
+            'absolute bottom-3 right-3 flex h-12 items-center gap-2 rounded-full bg-[var(--color-primary)] px-4 shadow-lg origin-bottom-right transition-all duration-200 ease-out motion-reduce:transition-none',
+            isCompact
+              ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+              : 'pointer-events-none translate-y-2 scale-90 opacity-0'
+          )}
+        >
+          <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
+          <span className="text-[14px] font-semibold text-[var(--color-on-primary)]">
+            {convertToCurrency(totalProductsValue)}
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+**O que mudou em relação ao arquivo original e por quê:**
+- O wrapper externo virou `fixed inset-x-0 bottom-0 pointer-events-none`, e o wrapper interno ganhou `relative` para ancorar o FAB via `absolute`. `pointer-events-none` no wrapper é essencial: sem isso a faixa transparente do footer intercepta toques na lista atrás dele.
+- O card expandido manteve exatamente o mesmo markup interno (totais, botão primário, scanner) — só ganhou as classes de transição e `pointer-events`/`tabIndex` condicionais.
+- Os dois botões do card recebem `tabIndex={isCompact ? -1 : 0}` porque `aria-hidden` no container **não** remove os filhos da ordem de tabulação. Sem isso, um usuário de teclado focaria botões invisíveis no modo compacto.
+- O FAB usa `aria-label="Expandir resumo do carrinho"`, não "Adicionar produto": o toque nele apenas reexpande o card (decisão registrada na spec). Rotular como "Adicionar produto" enganaria leitor de tela.
+- `motion-reduce:transition-none` em ambas as camadas respeita `prefers-reduced-motion`.
+
+- [ ] **Step 2: Verificar tipos e lint**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: nenhum erro.
+
+```bash
+npm run lint
+```
+
+Esperado: `✔ No ESLint warnings or errors`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/sticky-footer.tsx
+git commit -m "feat(sticky-footer): adiciona estado compacto em FAB com transicao animada"
+```
+
+---
+
+## Task 3: Ligar `FOOTER_CLEARANCE_PX` no `category-client`
+
+**Files:**
+- Modify: `src/app/category/category-client.tsx` (import + linha ~290)
+
+- [ ] **Step 1: Atualizar o import do `StickyFooter`**
+
+Localize esta linha em `src/app/category/category-client.tsx`:
+
+```tsx
+import { StickyFooter } from '@/components/sticky-footer';
+```
+
+Substitua por:
+
+```tsx
+import { StickyFooter, FOOTER_CLEARANCE_PX } from '@/components/sticky-footer';
+```
+
+A linha cresce mas permanece na posição correta da escada de imports do arquivo (ela já é uma das mais longas do bloco; confira que as linhas seguintes — `section-header`, `category-select`, `category-hero-card` — continuam iguais ou maiores em número de caracteres e reordene o bloco de imports se necessário, seguindo `.claude/rules/organization.md`).
+
+- [ ] **Step 2: Trocar o padding fixo pelo valor da constante**
+
+Localize esta linha (aproximadamente linha 290, dentro do `return` do componente):
+
+```tsx
+      <div className="flex flex-col gap-4 pb-[140px]">
+```
+
+Substitua por:
+
+```tsx
+      <div className="flex flex-col gap-4" style={{ paddingBottom: FOOTER_CLEARANCE_PX }}>
+```
+
+**Por que `style` e não uma classe Tailwind:** o JIT do Tailwind não resolve valores arbitrários a partir de constantes JS — `pb-[${FOOTER_CLEARANCE_PX}px]` não gera CSS nenhum e o padding simplesmente desapareceria. O `style` inline garante uma fonte única de verdade compartilhada entre o espaço reservado da lista e o `bottomOffset` da detecção de fim de página.
+
+- [ ] **Step 3: Verificar tipos e lint**
+
+```bash
+npx tsc --noEmit
+```
+
+Esperado: nenhum erro.
+
+```bash
+npm run lint
+```
+
+Esperado: `✔ No ESLint warnings or errors`
+
+- [ ] **Step 4: Confirmar que não sobrou nenhum `140px` órfão**
+
+```bash
+git grep -n "140px" -- src/
+```
+
+Esperado: nenhuma saída. Se aparecer alguma ocorrência, ela é um resquício do valor mágico antigo e deve passar a usar `FOOTER_CLEARANCE_PX`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/category/category-client.tsx
+git commit -m "refactor(category): usa FOOTER_CLEARANCE_PX no espaco reservado da lista"
+```
+
+---
+
+## Task 4: Validação manual no browser
+
+Não há testes automatizados no projeto, então esta task é a verificação real de que a feature funciona. **Não marque a implementação como concluída sem executá-la.**
+
+**Files:** nenhum (validação)
+
+- [ ] **Step 1: Subir o servidor de dev**
+
+Use a ferramenta de preview do harness com a config `easy-list-dev` (definida em `.claude/launch.json`, porta 3000). **Não** rode `npm run dev` via Bash.
+
+- [ ] **Step 2: Abrir uma categoria com lista longa**
+
+Navegue até a home, entre em uma categoria que tenha produtos suficientes para gerar scroll. Se nenhuma categoria tiver produtos suficientes, redimensione a viewport para `mobile` (375x812) — isso torna qualquer lista com ~8 itens rolável.
+
+- [ ] **Step 3: Checar erros de console e rede**
+
+Leia as mensagens de console e os logs do servidor. Esperado: nenhum erro novo. Um erro comum a procurar: `Cannot read properties of undefined` vindo do hook caso `document.documentElement` seja acessado durante SSR — o hook só toca em `window`/`document` dentro do `useEffect`, então isso não deve acontecer.
+
+- [ ] **Step 4: Percorrer os 7 cenários da spec**
+
+| # | Ação | Resultado esperado |
+|---|---|---|
+| 1 | Scroll para baixo na lista | Card colapsa em FAB pill no canto inferior direito, com animação suave |
+| 2 | Scroll para cima | FAB reexpande no card completo |
+| 3 | Tocar no FAB em modo compacto | Reexpande imediatamente; "Adicionar produto" abre o sheet normalmente em seguida |
+| 4 | Rolar até o fim da lista | Card fica expandido e não colapsa, mesmo continuando o gesto para baixo |
+| 5 | Lista curta (sem scroll disponível) | Card permanece expandido |
+| 6 | `prefers-reduced-motion: reduce` ativo | Troca de estado sem animação |
+| 7 | Tocar em um produto atrás da faixa do footer | O toque atinge o produto (`pointer-events` do wrapper não bloqueia) |
+
+Para o cenário 6, force a preferência no browser via:
+
+```js
+matchMedia('(prefers-reduced-motion: reduce)').matches
+```
+
+Se retornar `false`, use as devtools do browser para emular `prefers-reduced-motion: reduce` (Rendering → Emulate CSS media feature) e repita o cenário 1.
+
+Para o cenário 7, verifique que o último produto da lista continua clicável — é ele que fica sob a área do footer.
+
+- [ ] **Step 5: Capturar evidência**
+
+Tire um screenshot do estado compacto (FAB visível) e um do estado expandido. Compartilhe ambos.
+
+- [ ] **Step 6: Se algum cenário falhar**
+
+Não ajuste os números às cegas. Diagnostique primeiro:
+- **FAB pisca no primeiro paint:** valores iniciais de `useState` no hook estão invertidos.
+- **Nunca colapsa:** `isNearBottom` está sempre `true` — provavelmente `bottomOffset` grande demais em relação à altura da página, ou a página não tem scroll suficiente. Confirme com `document.documentElement.scrollHeight > window.innerHeight`.
+- **Colapsa mas não reexpande no fim da lista:** `bottomOffset` menor que a altura real do card. Meça a altura renderizada do card e ajuste `FOOTER_CLEARANCE_PX` (ele controla os dois lados, então continua consistente).
+- **Toques na lista não funcionam:** falta `pointer-events-none` no wrapper `fixed` ou `pointer-events-auto` na camada ativa.
+
+---
+
+## Fora de escopo (não faça)
+
+- Adicionar `framer-motion` ou qualquer lib de animação.
+- Aplicar o mesmo padrão ao `Footer` da home (`src/components/footer.tsx`).
+- Persistir o estado expandido/compacto entre navegações.
+- Tornar o scanner acessível no modo compacto.
+- Disparar `onAddProduct` direto do FAB.
+- Criar uma suíte de testes para este projeto.

--- a/docs/superpowers/specs/2026-07-31-sticky-footer-compact-fab-design.md
+++ b/docs/superpowers/specs/2026-07-31-sticky-footer-compact-fab-design.md
@@ -51,7 +51,7 @@ export function useScrollDirection(
   ```
   `isNearBottom` é recalculado em todo tick (não é gated pelo `threshold`), porque atingir o fim da página precisa ser detectado mesmo em movimentos pequenos.
 - Cleanup no `useEffect`: remove o listener e cancela qualquer `requestAnimationFrame` pendente (o id do frame é guardado em ref para isso), evitando `setState` após o unmount.
-- Executa uma medição inicial no mount, para o caso de a página já abrir rolada (restauração de scroll do browser).
+- Executa uma medição inicial no mount para inicializar `isNearBottom`, cobrindo o caso de a página já abrir rolada (restauração de scroll do browser). Note que essa medição **não** pode definir `isScrollingDown`: `lastScrollY` é igualado a `window.scrollY` imediatamente antes dela, então `delta` é sempre `0` no mount e o estado inicial permanece expandido — que é o padrão correto.
 
 **Isolamento:** o hook é chamado **apenas** dentro de `StickyFooter`. A lista de produtos e o resto da árvore não re-renderizam a cada tick de scroll.
 
@@ -59,14 +59,16 @@ export function useScrollDirection(
 
 ### 2. Constante `FOOTER_CLEARANCE_PX`
 
-Hoje o valor `140` existe duplicado implicitamente: como `pb-[140px]` em [category-client.tsx:290](../../../src/app/category/category-client.tsx) e como a altura real do card. Ele passa a ser exportado de `sticky-footer.tsx`:
+Hoje o valor `140` existe duplicado: como `pb-[140px]` em [category-client.tsx](../../../src/app/category/category-client.tsx), como `pb-[140px]` em [category-page-skeleton.tsx](../../../src/components/category-page-skeleton.tsx) (o skeleton da mesma página, com o container idêntico) e como a altura real do card. Ele passa a viver num módulo próprio, [src/lib/constants.ts](../../../src/lib/constants.ts):
 
 ```ts
 export const FOOTER_CLEARANCE_PX = 140;
 ```
 
 - `StickyFooter` usa como `bottomOffset` do hook.
-- `category-client.tsx` troca `pb-[140px]` por `style={{ paddingBottom: FOOTER_CLEARANCE_PX }}` no container da lista.
+- `category-client.tsx` e `category-page-skeleton.tsx` trocam `pb-[140px]` por `style={{ paddingBottom: FOOTER_CLEARANCE_PX }}` nos seus containers.
+
+**Motivo de um módulo separado em vez de exportar de `sticky-footer.tsx`:** `sticky-footer.tsx` é `'use client'`. Se a constante morasse lá, o skeleton (que não declara diretiva) estaria importando um export não-componente de um módulo client — o que funciona hoje só porque o único consumidor do skeleton também é client, e passaria a ser rejeitado pelo Next.js no dia em que alguém renderizasse `<CategoryPageSkeleton />` de um Server Component. `src/lib/constants.ts` não tem diretiva e é seguro nos dois lados da fronteira.
 
 **Motivo do `style` em vez de classe Tailwind:** o JIT do Tailwind não resolve valores arbitrários a partir de constantes JS (`pb-[${X}px]` não gera CSS). Usar `style` garante uma fonte única de verdade compartilhada entre o espaço reservado e a detecção de fim de lista, evitando que os dois dessincronizem.
 
@@ -150,7 +152,7 @@ Duas camadas irmãs dentro de um wrapper `fixed`, com cross-fade + `scale`/`tran
 
 ### 5. Acessibilidade
 
-- A camada inativa recebe `aria-hidden` **e** `pointer-events-none` **e** (no caso do FAB) `tabIndex={-1}`. Nunca fica clicável nem focável enquanto invisível — evita foco em elemento oculto e cliques fantasma.
+- A camada inativa recebe `inert`, `aria-hidden` e `pointer-events-none` (e `tabIndex={-1}` nos botões). Nunca fica clicável nem focável enquanto invisível — evita foco em elemento oculto e cliques fantasma. O `inert` é o que realmente cumpre a garantia: `tabIndex={-1}` remove da ordem de tabulação, mas **não** desfoca um elemento que já estava focado, então sem ele um usuário de teclado poderia dar Tab em "Adicionar produto", rolar até o card colapsar e apertar Enter num controle invisível. `tabIndex` e `aria-hidden` são mantidos junto como redundância defensiva.
 - `motion-reduce:transition-none` respeita `prefers-reduced-motion`: a troca acontece instantaneamente, sem animação.
 - O FAB tem `aria-label="Expandir resumo do carrinho"`. Apesar do ícone `Plus`, sua ação é **reexpandir**, não adicionar produto — rotulá-lo como "Adicionar produto" enganaria leitores de tela.
 - O botão "Adicionar produto" permanece funcional e acessível sempre que o card está expandido, incluindo após reexpansão via FAB.
@@ -161,9 +163,11 @@ Duas camadas irmãs dentro de um wrapper `fixed`, com cross-fade + `scale`/`tran
 
 | Arquivo | Mudança |
 |---|---|
+| `src/lib/constants.ts` | Novo — declara `FOOTER_CLEARANCE_PX` fora da fronteira client |
 | `src/hooks/useScrollDirection.ts` | Novo — hook de direção de scroll + detecção de fim de página |
-| `src/components/sticky-footer.tsx` | Refatoração: dois estados visuais, `FOOTER_CLEARANCE_PX`, FAB compacto |
+| `src/components/sticky-footer.tsx` | Refatoração: dois estados visuais, FAB compacto |
 | `src/app/category/category-client.tsx` | `pb-[140px]` → `style={{ paddingBottom: FOOTER_CLEARANCE_PX }}` |
+| `src/components/category-page-skeleton.tsx` | `pb-[140px]` → `style={{ paddingBottom: FOOTER_CLEARANCE_PX }}` |
 
 ---
 

--- a/docs/superpowers/specs/2026-07-31-sticky-footer-compact-fab-design.md
+++ b/docs/superpowers/specs/2026-07-31-sticky-footer-compact-fab-design.md
@@ -50,7 +50,7 @@ export function useScrollDirection(
   window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - bottomOffset
   ```
   `isNearBottom` é recalculado em todo tick (não é gated pelo `threshold`), porque atingir o fim da página precisa ser detectado mesmo em movimentos pequenos.
-- Cleanup no `useEffect`: remove o listener e cancela qualquer `requestAnimationFrame` pendente.
+- Cleanup no `useEffect`: remove o listener e cancela qualquer `requestAnimationFrame` pendente (o id do frame é guardado em ref para isso), evitando `setState` após o unmount.
 - Executa uma medição inicial no mount, para o caso de a página já abrir rolada (restauração de scroll do browser).
 
 **Isolamento:** o hook é chamado **apenas** dentro de `StickyFooter`. A lista de produtos e o resto da árvore não re-renderizam a cada tick de scroll.

--- a/docs/superpowers/specs/2026-07-31-sticky-footer-compact-fab-design.md
+++ b/docs/superpowers/specs/2026-07-31-sticky-footer-compact-fab-design.md
@@ -1,0 +1,189 @@
+# Design: StickyFooter Expandido ↔ Compacto (FAB)
+
+**Data:** 2026-07-31
+**Status:** Aprovado
+
+---
+
+## Contexto
+
+O `StickyFooter` ([src/components/sticky-footer.tsx](../../../src/components/sticky-footer.tsx)) é um card fixo na base da página de categoria. Ele exibe o total, o subtotal do carrinho, o botão primário "Adicionar produto" e o botão de scanner de código de barras. O card ocupa ~140px de altura, e `category-client.tsx` reserva esse espaço com `pb-[140px]` no container da lista para o conteúdo não ficar escondido atrás dele.
+
+Em listas longas esse card come uma fatia relevante da viewport em telas pequenas. O objetivo é colapsá-lo em um FAB compacto durante o scroll para baixo, devolvendo espaço vertical para a lista, e reexpandi-lo quando o usuário sinalizar interesse (scroll para cima, toque no FAB, ou chegada ao fim da lista).
+
+**Restrições do projeto:**
+- O scroll é da janela (`window`) — a lista **não** tem container de scroll próprio.
+- `framer-motion` **não** está instalado. As libs de animação/gesto presentes são `vaul` (drawers) e `@use-gesture/react`. Decidido: **não** adicionar dependência nova; a transição usa CSS (`transform`/`opacity`), consistente com o padrão de colapso já usado nas seções da lista (`grid-rows-[0fr]` + `transition-all`).
+- O projeto não possui suíte de testes automatizados. A validação é manual no browser.
+
+---
+
+## Funcionalidades
+
+### 1. Hook `useScrollDirection`
+
+**Novo arquivo:** `src/hooks/useScrollDirection.ts`
+
+```ts
+interface UseScrollDirectionOptions {
+  threshold?: number;      // default: 15
+  bottomOffset?: number;   // default: 0
+}
+
+interface UseScrollDirectionResult {
+  isNearBottom: boolean;
+  isScrollingDown: boolean;
+}
+
+export function useScrollDirection(
+  options?: UseScrollDirectionOptions
+): UseScrollDirectionResult;
+```
+
+**Comportamento:**
+
+- Registra **um único** listener `scroll` em `window` com `{ passive: true }`.
+- Coalesce os eventos via `requestAnimationFrame` usando uma flag `ticking` em `useRef` — no máximo um cálculo por frame, independente de quantos eventos de scroll o browser disparar.
+- Mantém `lastScrollY` em `useRef`. Só chama `setIsScrollingDown` quando `Math.abs(scrollY - lastScrollY) > threshold`, evitando jitter em micro-scrolls e re-renders desnecessários. `lastScrollY` só é atualizado quando o threshold é superado, para que scrolls pequenos e sucessivos na mesma direção acumulem até cruzar o limite em vez de serem descartados um a um.
+- `isNearBottom` é calculado como:
+  ```ts
+  window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - bottomOffset
+  ```
+  `isNearBottom` é recalculado em todo tick (não é gated pelo `threshold`), porque atingir o fim da página precisa ser detectado mesmo em movimentos pequenos.
+- Cleanup no `useEffect`: remove o listener e cancela qualquer `requestAnimationFrame` pendente.
+- Executa uma medição inicial no mount, para o caso de a página já abrir rolada (restauração de scroll do browser).
+
+**Isolamento:** o hook é chamado **apenas** dentro de `StickyFooter`. A lista de produtos e o resto da árvore não re-renderizam a cada tick de scroll.
+
+---
+
+### 2. Constante `FOOTER_CLEARANCE_PX`
+
+Hoje o valor `140` existe duplicado implicitamente: como `pb-[140px]` em [category-client.tsx:290](../../../src/app/category/category-client.tsx) e como a altura real do card. Ele passa a ser exportado de `sticky-footer.tsx`:
+
+```ts
+export const FOOTER_CLEARANCE_PX = 140;
+```
+
+- `StickyFooter` usa como `bottomOffset` do hook.
+- `category-client.tsx` troca `pb-[140px]` por `style={{ paddingBottom: FOOTER_CLEARANCE_PX }}` no container da lista.
+
+**Motivo do `style` em vez de classe Tailwind:** o JIT do Tailwind não resolve valores arbitrários a partir de constantes JS (`pb-[${X}px]` não gera CSS). Usar `style` garante uma fonte única de verdade compartilhada entre o espaço reservado e a detecção de fim de lista, evitando que os dois dessincronizem.
+
+---
+
+### 3. Máquina de estado do `StickyFooter`
+
+```ts
+const { isNearBottom, isScrollingDown } = useScrollDirection({
+  bottomOffset: FOOTER_CLEARANCE_PX,
+});
+const [forceExpanded, setForceExpanded] = useState(false);
+
+useEffect(() => {
+  if (isScrollingDown) setForceExpanded(false);
+}, [isScrollingDown]);
+
+const isCompact = isScrollingDown && !isNearBottom && !forceExpanded;
+```
+
+| Gatilho | Resultado |
+|---|---|
+| Scroll para baixo (> 15px) | Compacta (FAB) |
+| Scroll para cima (> 15px) | Expande (`isScrollingDown` → `false`) |
+| Toque no FAB | Expande imediatamente (`forceExpanded = true`) |
+| Fim da lista alcançado | Força expandido, mesmo durante scroll down |
+
+O override `forceExpanded` é descartado na próxima **transição** para scroll-down — ou seja, quando `isScrollingDown` passa de `false` para `true`. Consequência aceita: se o usuário tocar no FAB e seguir rolando para baixo sem nunca rolar para cima, o card permanece expandido, porque `isScrollingDown` já era `true` e não houve transição. Isso é intencional: o toque é um sinal explícito de intenção do usuário e não deve ser revogado pelo mesmo gesto que o precedeu.
+
+---
+
+### 4. Markup e animação
+
+Duas camadas irmãs dentro de um wrapper `fixed`, com cross-fade + `scale`/`translate` e `transition-all duration-200 ease-out`.
+
+**Por que cross-fade e não morph geométrico:** o card expandido é centralizado e largo (`max-w-3xl`), o FAB é ancorado no canto inferior direito e estreito. Animar essa mudança de geometria como um único elemento exigiria layout animations (o `layout` do `framer-motion`) — descartado por não justificar a dependência. O cross-fade de duas camadas entrega uma transição fluida sem lib nova.
+
+```tsx
+<div className="fixed inset-x-0 bottom-0 z-10 pointer-events-none">
+  <div className="relative mx-auto max-w-3xl p-3">
+    {/* Camada 1: card expandido — markup atual preservado */}
+    <div
+      aria-hidden={isCompact}
+      className={cn(
+        'origin-bottom transition-all duration-200 ease-out motion-reduce:transition-none',
+        isCompact
+          ? 'pointer-events-none translate-y-2 scale-95 opacity-0'
+          : 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+      )}
+    >
+      {/* card com Total, Carrinho, "Adicionar produto" e scanner */}
+    </div>
+
+    {/* Camada 2: FAB pill compacto */}
+    <button
+      type="button"
+      tabIndex={isCompact ? 0 : -1}
+      aria-hidden={!isCompact}
+      aria-label="Expandir resumo do carrinho"
+      onClick={() => setForceExpanded(true)}
+      className={cn(
+        'absolute bottom-3 right-3 origin-bottom-right transition-all duration-200 ease-out motion-reduce:transition-none',
+        isCompact
+          ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+          : 'pointer-events-none translate-y-2 scale-90 opacity-0'
+      )}
+    >
+      <Plus /> {convertToCurrency(totalProductsValue)}
+    </button>
+  </div>
+</div>
+```
+
+**Wrapper:** `pointer-events-none` no wrapper `fixed` + `pointer-events-auto` só na camada ativa. Isso impede que a faixa transparente do wrapper intercepte toques na lista atrás dele.
+
+**FAB (formato escolhido — pill horizontal):** ícone `Plus` + valor total resumido, ancorado no canto inferior direito. Usa os tokens visuais existentes (`--color-primary`, `--color-on-primary`, `--radius-*`) para se manter dentro do design system do projeto.
+
+**Botão de scanner:** existe **apenas** no card expandido. Não é replicado no FAB — o modo compacto é um resumo/atalho de reabertura, não uma barra de ações.
+
+---
+
+### 5. Acessibilidade
+
+- A camada inativa recebe `aria-hidden` **e** `pointer-events-none` **e** (no caso do FAB) `tabIndex={-1}`. Nunca fica clicável nem focável enquanto invisível — evita foco em elemento oculto e cliques fantasma.
+- `motion-reduce:transition-none` respeita `prefers-reduced-motion`: a troca acontece instantaneamente, sem animação.
+- O FAB tem `aria-label="Expandir resumo do carrinho"`. Apesar do ícone `Plus`, sua ação é **reexpandir**, não adicionar produto — rotulá-lo como "Adicionar produto" enganaria leitores de tela.
+- O botão "Adicionar produto" permanece funcional e acessível sempre que o card está expandido, incluindo após reexpansão via FAB.
+
+---
+
+## Arquivos afetados
+
+| Arquivo | Mudança |
+|---|---|
+| `src/hooks/useScrollDirection.ts` | Novo — hook de direção de scroll + detecção de fim de página |
+| `src/components/sticky-footer.tsx` | Refatoração: dois estados visuais, `FOOTER_CLEARANCE_PX`, FAB compacto |
+| `src/app/category/category-client.tsx` | `pb-[140px]` → `style={{ paddingBottom: FOOTER_CLEARANCE_PX }}` |
+
+---
+
+## Validação (manual, no browser)
+
+1. Scroll para baixo em uma lista longa → card colapsa em FAB pill no canto inferior direito, com animação suave.
+2. Scroll para cima → FAB reexpande no card completo.
+3. Toque no FAB em modo compacto → reexpande imediatamente; "Adicionar produto" abre o sheet normalmente em seguida.
+4. Rolar até o fim da lista → card fica expandido e não colapsa, mesmo continuando o gesto para baixo.
+5. Lista curta (sem scroll disponível) → card permanece expandido.
+6. Com `prefers-reduced-motion: reduce` ativo → troca de estado sem animação.
+7. Toques na lista atrás da faixa do footer continuam funcionando (`pointer-events`).
+
+---
+
+## Fora de escopo
+
+- Adicionar `framer-motion` ao projeto.
+- Aplicar o mesmo padrão ao `Footer` da home (`src/components/footer.tsx`).
+- Persistir o estado expandido/compacto entre navegações.
+- Ação de scanner acessível no modo compacto.
+- Disparar `onAddProduct` direto do FAB (decidido: o toque só reexpande).
+- Testes automatizados — o projeto não possui suíte hoje.

--- a/src/app/category/category-client.tsx
+++ b/src/app/category/category-client.tsx
@@ -9,7 +9,9 @@ import { cn } from '@/lib/utils';
 import { ProductProps } from '@/types/interfaces';
 import { StateCard } from '@/components/state-card';
 import { ProductRow } from '@/components/product-row';
+import { FOOTER_CLEARANCE_PX } from '@/lib/constants';
 import { useProducts, useCategories } from '@/context';
+import { StickyFooter } from '@/components/sticky-footer';
 import { SectionHeader } from '@/components/section-header';
 import { CategorySelect } from '@/components/category-select';
 import { CategoryHeroCard } from '@/components/category-hero-card';
@@ -18,7 +20,6 @@ import { SubcategoryHeader } from '@/components/subcategory-header';
 import { BarcodeScannerSheet } from '@/components/barcode-scanner-sheet';
 import { ProductManagerSheet } from '@/components/product-manager-sheet';
 import { CategoryPageSkeleton } from '@/components/category-page-skeleton';
-import { StickyFooter, FOOTER_CLEARANCE_PX } from '@/components/sticky-footer';
 import { BarcodeLookupResult, BarcodeProductPreview } from '@/components/barcode-product-preview';
 
 function groupProductsBySubcategory(

--- a/src/app/category/category-client.tsx
+++ b/src/app/category/category-client.tsx
@@ -10,7 +10,6 @@ import { ProductProps } from '@/types/interfaces';
 import { StateCard } from '@/components/state-card';
 import { ProductRow } from '@/components/product-row';
 import { useProducts, useCategories } from '@/context';
-import { StickyFooter } from '@/components/sticky-footer';
 import { SectionHeader } from '@/components/section-header';
 import { CategorySelect } from '@/components/category-select';
 import { CategoryHeroCard } from '@/components/category-hero-card';
@@ -19,6 +18,7 @@ import { SubcategoryHeader } from '@/components/subcategory-header';
 import { BarcodeScannerSheet } from '@/components/barcode-scanner-sheet';
 import { ProductManagerSheet } from '@/components/product-manager-sheet';
 import { CategoryPageSkeleton } from '@/components/category-page-skeleton';
+import { StickyFooter, FOOTER_CLEARANCE_PX } from '@/components/sticky-footer';
 import { BarcodeLookupResult, BarcodeProductPreview } from '@/components/barcode-product-preview';
 
 function groupProductsBySubcategory(
@@ -287,7 +287,7 @@ export function CategoryClient() {
 
   return (
     <>
-      <div className="flex flex-col gap-4 pb-[140px]">
+      <div className="flex flex-col gap-4" style={{ paddingBottom: FOOTER_CLEARANCE_PX }}>
         <nav aria-label="breadcrumb" className="flex items-center gap-1.5">
           <Link href="/" className="text-[12px] font-semibold text-[var(--color-ink)]">
             Home

--- a/src/components/category-page-skeleton.tsx
+++ b/src/components/category-page-skeleton.tsx
@@ -1,4 +1,4 @@
-import { FOOTER_CLEARANCE_PX } from '@/components/sticky-footer';
+import { FOOTER_CLEARANCE_PX } from '@/lib/constants';
 
 const skel = 'bg-[var(--color-hairline)] animate-pulse';
 

--- a/src/components/category-page-skeleton.tsx
+++ b/src/components/category-page-skeleton.tsx
@@ -1,8 +1,10 @@
+import { FOOTER_CLEARANCE_PX } from '@/components/sticky-footer';
+
 const skel = 'bg-[var(--color-hairline)] animate-pulse';
 
 export function CategoryPageSkeleton() {
   return (
-    <div className="flex flex-col gap-4 pb-[140px]">
+    <div className="flex flex-col gap-4" style={{ paddingBottom: FOOTER_CLEARANCE_PX }}>
       {/* Breadcrumb */}
       <div className="flex items-center gap-1.5">
         <div className={`${skel} h-3 w-9 rounded-sm`} />

--- a/src/components/sticky-footer.tsx
+++ b/src/components/sticky-footer.tsx
@@ -20,6 +20,7 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
     bottomOffset: FOOTER_CLEARANCE_PX,
   });
 
+  const [isSettling, setIsSettling] = useState(false);
   const [forceExpanded, setForceExpanded] = useState(false);
 
   const { totalProductsValue, filteredProductsValue } =
@@ -28,6 +29,14 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
   useEffect(() => {
     if (isScrollingDown) setForceExpanded(false);
   }, [isScrollingDown]);
+
+  useEffect(() => {
+    if (!isSettling) return;
+
+    const timeoutId = setTimeout(() => setIsSettling(false), 250);
+
+    return () => clearTimeout(timeoutId);
+  }, [isSettling]);
 
   const isCompact = isScrollingDown && !isNearBottom && !forceExpanded;
 
@@ -39,9 +48,8 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
           aria-hidden={isCompact}
           className={cn(
             'flex flex-col gap-3 rounded-[var(--radius-xl)] bg-[var(--color-canvas)] border border-[var(--color-hairline)] p-3 origin-bottom transition-all duration-200 ease-out motion-reduce:transition-none',
-            isCompact
-              ? 'pointer-events-none translate-y-2 scale-95 opacity-0'
-              : 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+            isCompact ? 'translate-y-2 scale-95 opacity-0' : 'translate-y-0 scale-100 opacity-100',
+            !isCompact && !isSettling ? 'pointer-events-auto' : 'pointer-events-none'
           )}
         >
           {/* Totals row */}
@@ -95,7 +103,10 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
           inert={!isCompact}
           aria-hidden={!isCompact}
           tabIndex={isCompact ? 0 : -1}
-          onClick={() => setForceExpanded(true)}
+          onClick={() => {
+            setIsSettling(true);
+            setForceExpanded(true);
+          }}
           aria-label="Expandir resumo do carrinho"
           className={cn(
             'absolute bottom-3 right-3 flex h-12 items-center gap-2 rounded-full bg-[var(--color-primary)] px-4 shadow-lg origin-bottom-right transition-all duration-200 ease-out motion-reduce:transition-none',

--- a/src/components/sticky-footer.tsx
+++ b/src/components/sticky-footer.tsx
@@ -49,7 +49,7 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
           className={cn(
             'flex flex-col gap-3 rounded-[var(--radius-xl)] bg-[var(--color-canvas)] border border-[var(--color-hairline)] p-3 origin-bottom transition-all duration-200 ease-out motion-reduce:transition-none',
             isCompact ? 'translate-y-2 scale-95 opacity-0' : 'translate-y-0 scale-100 opacity-100',
-            !isCompact && !isSettling ? 'pointer-events-auto' : 'pointer-events-none'
+            !isCompact ? 'pointer-events-auto' : 'pointer-events-none'
           )}
         >
           {/* Totals row */}
@@ -75,7 +75,10 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
                 (e.currentTarget as HTMLButtonElement).blur();
                 onAddProduct();
               }}
-              className="flex h-12 items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)]"
+              className={cn(
+                'flex h-12 items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)]',
+                isSettling && 'pointer-events-none'
+              )}
             >
               <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
               <span className="text-[14px] font-semibold text-[var(--color-on-primary)]">
@@ -91,7 +94,10 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
                 (e.currentTarget as HTMLButtonElement).blur();
                 onScanProduct();
               }}
-              className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-surface-card)]"
+              className={cn(
+                'flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-surface-card)]',
+                isSettling && 'pointer-events-none'
+              )}
             >
               <ScanLine className="h-[15px] w-[15px] text-[var(--color-ink)]" />
             </button>

--- a/src/components/sticky-footer.tsx
+++ b/src/components/sticky-footer.tsx
@@ -1,9 +1,14 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { Plus, ScanLine } from 'lucide-react';
 
+import { cn } from '@/lib/utils';
 import { ProductProps } from '@/types/interfaces';
+import { useScrollDirection } from '@/hooks/useScrollDirection';
 import { convertToCurrency, calculateTotalValue } from '@/utils';
+
+export const FOOTER_CLEARANCE_PX = 140;
 
 interface StickyFooterProps {
   products: ProductProps[];
@@ -12,54 +17,97 @@ interface StickyFooterProps {
 }
 
 export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFooterProps) {
+  const { isNearBottom, isScrollingDown } = useScrollDirection({
+    bottomOffset: FOOTER_CLEARANCE_PX,
+  });
+
+  const [forceExpanded, setForceExpanded] = useState(false);
+
   const { totalProductsValue, filteredProductsValue } =
     calculateTotalValue(products);
 
+  useEffect(() => {
+    if (isScrollingDown) setForceExpanded(false);
+  }, [isScrollingDown]);
+
+  const isCompact = isScrollingDown && !isNearBottom && !forceExpanded;
+
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-10 p-3 max-w-3xl mx-auto">
-      <div className="flex flex-col gap-3 rounded-[var(--radius-xl)] bg-[var(--color-canvas)] border border-[var(--color-hairline)] p-3">
-        {/* Totals row */}
-        <div className="flex items-center justify-between w-full">
-          <div className="flex flex-col gap-0.5">
-            <span className="text-[12px] font-semibold text-[var(--color-muted)]">
-              Total
-            </span>
-            <span className="text-[12px] font-medium text-[var(--color-muted)]">
-              Carrinho: {convertToCurrency(filteredProductsValue)}
+    <div className="fixed inset-x-0 bottom-0 z-10 pointer-events-none">
+      <div className="relative mx-auto max-w-3xl p-3">
+        <div
+          aria-hidden={isCompact}
+          className={cn(
+            'flex flex-col gap-3 rounded-[var(--radius-xl)] bg-[var(--color-canvas)] border border-[var(--color-hairline)] p-3 origin-bottom transition-all duration-200 ease-out motion-reduce:transition-none',
+            isCompact
+              ? 'pointer-events-none translate-y-2 scale-95 opacity-0'
+              : 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+          )}
+        >
+          {/* Totals row */}
+          <div className="flex items-center justify-between w-full">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-[12px] font-semibold text-[var(--color-muted)]">
+                Total
+              </span>
+              <span className="text-[12px] font-medium text-[var(--color-muted)]">
+                Carrinho: {convertToCurrency(filteredProductsValue)}
+              </span>
+            </div>
+            <span className="text-[22px] font-semibold text-[var(--color-ink)]">
+              {convertToCurrency(totalProductsValue)}
             </span>
           </div>
-          <span className="text-[22px] font-semibold text-[var(--color-ink)]">
+
+          <div className="grid grid-cols-[1fr_48px] gap-2">
+            <button
+              type="button"
+              tabIndex={isCompact ? -1 : 0}
+              onClick={(e) => {
+                (e.currentTarget as HTMLButtonElement).blur();
+                onAddProduct();
+              }}
+              className="flex h-12 items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)]"
+            >
+              <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
+              <span className="text-[14px] font-semibold text-[var(--color-on-primary)]">
+                Adicionar produto
+              </span>
+            </button>
+
+            <button
+              type="button"
+              aria-label="Escanear produto"
+              tabIndex={isCompact ? -1 : 0}
+              onClick={(e) => {
+                (e.currentTarget as HTMLButtonElement).blur();
+                onScanProduct();
+              }}
+              className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-surface-card)]"
+            >
+              <ScanLine className="h-[15px] w-[15px] text-[var(--color-ink)]" />
+            </button>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          aria-hidden={!isCompact}
+          tabIndex={isCompact ? 0 : -1}
+          onClick={() => setForceExpanded(true)}
+          aria-label="Expandir resumo do carrinho"
+          className={cn(
+            'absolute bottom-3 right-3 flex h-12 items-center gap-2 rounded-full bg-[var(--color-primary)] px-4 shadow-lg origin-bottom-right transition-all duration-200 ease-out motion-reduce:transition-none',
+            isCompact
+              ? 'pointer-events-auto translate-y-0 scale-100 opacity-100'
+              : 'pointer-events-none translate-y-2 scale-90 opacity-0'
+          )}
+        >
+          <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
+          <span className="text-[14px] font-semibold text-[var(--color-on-primary)]">
             {convertToCurrency(totalProductsValue)}
           </span>
-        </div>
-
-        <div className="grid grid-cols-[1fr_48px] gap-2">
-          <button
-            type="button"
-            onClick={(e) => {
-              (e.currentTarget as HTMLButtonElement).blur();
-              onAddProduct();
-            }}
-            className="flex h-12 items-center justify-center gap-2 rounded-[var(--radius-md)] bg-[var(--color-primary)]"
-          >
-            <Plus className="h-[18px] w-[18px] text-[var(--color-on-primary)]" />
-            <span className="text-[14px] font-semibold text-[var(--color-on-primary)]">
-              Adicionar produto
-            </span>
-          </button>
-
-          <button
-            type="button"
-            aria-label="Escanear produto"
-            onClick={(e) => {
-              (e.currentTarget as HTMLButtonElement).blur();
-              onScanProduct();
-            }}
-            className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-surface-card)]"
-          >
-            <ScanLine className="h-[15px] w-[15px] text-[var(--color-ink)]" />
-          </button>
-        </div>
+        </button>
       </div>
     </div>
   );

--- a/src/components/sticky-footer.tsx
+++ b/src/components/sticky-footer.tsx
@@ -5,10 +5,9 @@ import { Plus, ScanLine } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { ProductProps } from '@/types/interfaces';
+import { FOOTER_CLEARANCE_PX } from '@/lib/constants';
 import { useScrollDirection } from '@/hooks/useScrollDirection';
 import { convertToCurrency, calculateTotalValue } from '@/utils';
-
-export const FOOTER_CLEARANCE_PX = 140;
 
 interface StickyFooterProps {
   products: ProductProps[];
@@ -36,6 +35,7 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
     <div className="fixed inset-x-0 bottom-0 z-10 pointer-events-none">
       <div className="relative mx-auto max-w-3xl p-3">
         <div
+          inert={isCompact}
           aria-hidden={isCompact}
           className={cn(
             'flex flex-col gap-3 rounded-[var(--radius-xl)] bg-[var(--color-canvas)] border border-[var(--color-hairline)] p-3 origin-bottom transition-all duration-200 ease-out motion-reduce:transition-none',
@@ -46,15 +46,15 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
         >
           {/* Totals row */}
           <div className="flex items-center justify-between w-full">
-            <div className="flex flex-col gap-0.5">
-              <span className="text-[12px] font-semibold text-[var(--color-muted)]">
+            <div className="flex flex-col gap-0.5 min-w-0">
+              <span className="text-[12px] font-semibold text-[var(--color-muted)] truncate">
                 Total
               </span>
-              <span className="text-[12px] font-medium text-[var(--color-muted)]">
+              <span className="text-[12px] font-medium text-[var(--color-muted)] truncate">
                 Carrinho: {convertToCurrency(filteredProductsValue)}
               </span>
             </div>
-            <span className="text-[22px] font-semibold text-[var(--color-ink)]">
+            <span className="text-[22px] font-semibold text-[var(--color-ink)] shrink-0">
               {convertToCurrency(totalProductsValue)}
             </span>
           </div>
@@ -92,6 +92,7 @@ export function StickyFooter({ products, onAddProduct, onScanProduct }: StickyFo
 
         <button
           type="button"
+          inert={!isCompact}
           aria-hidden={!isCompact}
           tabIndex={isCompact ? 0 : -1}
           onClick={() => setForceExpanded(true)}

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -16,6 +16,7 @@ export function useScrollDirection({
   threshold = 15,
   bottomOffset = 0,
 }: UseScrollDirectionOptions = {}): UseScrollDirectionResult {
+  const rafIdRef = useRef<number | null>(null);
   const tickingRef = useRef(false);
   const lastScrollYRef = useRef(0);
 
@@ -44,7 +45,7 @@ export function useScrollDirection({
 
       tickingRef.current = true;
 
-      window.requestAnimationFrame(() => {
+      rafIdRef.current = window.requestAnimationFrame(() => {
         measure();
         tickingRef.current = false;
       });
@@ -56,6 +57,9 @@ export function useScrollDirection({
     window.addEventListener('scroll', handleScroll, { passive: true });
 
     return () => {
+      if (rafIdRef.current !== null) {
+        window.cancelAnimationFrame(rafIdRef.current);
+      }
       window.removeEventListener('scroll', handleScroll);
       tickingRef.current = false;
     };

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useRef, useState, useEffect } from 'react';
+
+interface UseScrollDirectionOptions {
+  threshold?: number;
+  bottomOffset?: number;
+}
+
+interface UseScrollDirectionResult {
+  isNearBottom: boolean;
+  isScrollingDown: boolean;
+}
+
+export function useScrollDirection({
+  threshold = 15,
+  bottomOffset = 0,
+}: UseScrollDirectionOptions = {}): UseScrollDirectionResult {
+  const tickingRef = useRef(false);
+  const lastScrollYRef = useRef(0);
+
+  const [isNearBottom, setIsNearBottom] = useState(true);
+  const [isScrollingDown, setIsScrollingDown] = useState(false);
+
+  useEffect(() => {
+    function measure() {
+      const scrollY = window.scrollY;
+      const reachedBottom =
+        scrollY + window.innerHeight >=
+        document.documentElement.scrollHeight - bottomOffset;
+
+      setIsNearBottom(reachedBottom);
+
+      const delta = scrollY - lastScrollYRef.current;
+
+      if (Math.abs(delta) > threshold) {
+        setIsScrollingDown(delta > 0);
+        lastScrollYRef.current = scrollY;
+      }
+    }
+
+    function handleScroll() {
+      if (tickingRef.current) return;
+
+      tickingRef.current = true;
+
+      window.requestAnimationFrame(() => {
+        measure();
+        tickingRef.current = false;
+      });
+    }
+
+    lastScrollYRef.current = window.scrollY;
+    measure();
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      tickingRef.current = false;
+    };
+  }, [threshold, bottomOffset]);
+
+  return { isNearBottom, isScrollingDown };
+}

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -16,9 +16,9 @@ export function useScrollDirection({
   threshold = 15,
   bottomOffset = 0,
 }: UseScrollDirectionOptions = {}): UseScrollDirectionResult {
-  const rafIdRef = useRef<number | null>(null);
-  const tickingRef = useRef(false);
   const lastScrollYRef = useRef(0);
+  const tickingRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
 
   const [isNearBottom, setIsNearBottom] = useState(true);
   const [isScrollingDown, setIsScrollingDown] = useState(false);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,2 @@
+/** Altura reservada na base da lista para o StickyFooter, em pixels. */
+export const FOOTER_CLEARANCE_PX = 140;


### PR DESCRIPTION
## Contexto

Na página de categoria, o `StickyFooter` é um card fixo na base que ocupa 124px de altura — em uma viewport de 812px isso é ~15% da tela permanentemente comprometida, e o container da lista ainda reserva 140px de padding para não ficar escondido atrás dele. Em listas longas (a lista de teste tem 74 itens) esse custo aparece a cada rolagem. Este PR faz o card se consolidar em um botão flutuante compacto (pill com `+` e o total) enquanto o usuário rola para baixo, devolvendo o espaço à lista, e reexpandir quando o usuário sinaliza interesse: rolando para cima, tocando no pill, ou chegando ao fim da lista.

A transição é feita com `transform`/`opacity` do Tailwind, sem adicionar biblioteca de animação. `framer-motion` foi considerado (o `layout` resolveria o morph geométrico entre card centralizado e pill ancorado no canto), mas foi descartado: são ~50kb de dependência nova para uma transição que um cross-fade de duas camadas entrega igual.

## O que foi feito

- **Novo hook `useScrollDirection`** — um único listener `scroll` em `window`, passivo e coalescido por `requestAnimationFrame`, expondo `isScrollingDown` e `isNearBottom`. O threshold de 15px evita jitter em micro-scrolls, e `lastScrollY` só avança quando o limite é cruzado, para que rolagens pequenas e sucessivas acumulem em vez de serem descartadas. O hook é chamado **apenas** dentro do `StickyFooter`, então a lista de produtos não re-renderiza a cada tick.
- **Duas camadas em cross-fade** no lugar de um card que se transforma. `isCompact` é o único booleano derivado, e cada classe de visibilidade e interatividade das duas camadas é chaveada por ele — não existe estado em que ambas estejam ativas ou ambas escondidas.
- **`FOOTER_CLEARANCE_PX` extraída para `src/lib/constants.ts`.** O valor 140 estava duplicado como `pb-[140px]` em dois lugares e implicitamente na altura real do card; agora ele governa o espaço reservado da lista **e** o `bottomOffset` da detecção de fim de página, de uma fonte só. Ficou num módulo sem diretiva de propósito: `sticky-footer.tsx` é `'use client'`, e o skeleton que também consome a constante não declara diretiva — hoje funciona por acidente da árvore, mas quebraria no dia em que o skeleton fosse renderizado de um Server Component.
- **Acessibilidade via `inert`, não só `tabIndex`.** `tabIndex={-1}` remove da ordem de tabulação mas não desfoca quem já está focado — dava para dar Tab em "Adicionar produto", rolar até o card colapsar e apertar Enter num controle invisível. O `inert` (React 19) resolve de fato; `tabIndex` e `aria-hidden` ficam como redundância defensiva. O pill tem `aria-label` próprio de expansão, porque apesar do ícone `+` ele não adiciona produto — só reexpande.
- **Guarda de 250ms contra toque duplo no pill.** O pill se sobrepõe geometricamente ao botão do scanner (48×22px, e o centro do pill cai dentro do retângulo do scanner), então um segundo toque durante o cross-fade abria a câmera. Durante a janela o card **captura** o toque (`pointer-events-auto` no container) e só os botões internos ficam inertes — o toque morre no fundo do card. A alternativa óbvia (desligar pointer-events no container) foi testada e é **pior**: como o wrapper `fixed` também é `pointer-events-none`, o toque atravessa e cai na lixeira de uma linha de produto.
- **Linha de totais protegida contra quebra** com `min-w-0`/`truncate`/`shrink-0`. Como a constante governa dois comportamentos, qualquer coisa que engorde o card erra os dois juntos; num viewport de 320px um total grande quebrava para duas linhas e passava dos 140px reservados.
- **Skeleton alinhado** — `category-page-skeleton.tsx` tinha o mesmo `pb-[140px]` e passou a consumir a constante.

Validado no browser em 375×812 e 320×812 com a lista de 74 itens: card medido em 124px (dentro dos 140px reservados), compactação e reexpansão nos quatro gatilhos, fim de lista forçando expandido, foco saindo da camada inerte, e toques atrás da faixa do footer chegando à lista.