### PR TITLE
feat(category): adiciona opcao de selecionar/desselecionar todos os itens do carrinho em lote

### DIFF
--- a/src/app/api/categories/[id]/cart/route.ts
+++ b/src/app/api/categories/[id]/cart/route.ts
@@ -1,0 +1,39 @@
+import { getToken } from 'next-auth/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { authSecret } from '@/lib/auth-secret';
+import { toggleBatchCart } from '@/lib/firestore-domain';
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const token = await getToken({ req: request, secret: authSecret });
+    const userId = token?.sub ?? null;
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 });
+    }
+
+    const { id: categoryId } = await context.params;
+    const body = await request.json() as { addToCart?: boolean; productIds?: string[] };
+    const { addToCart, productIds } = body;
+
+    if (typeof addToCart !== 'boolean') {
+      return NextResponse.json({ error: 'Parâmetro addToCart é obrigatório' }, { status: 400 });
+    }
+
+    const success = await toggleBatchCart(userId, categoryId, addToCart, productIds);
+
+    if (!success) {
+      return NextResponse.json({ error: 'Categoria não encontrada' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Erro ao atualizar produtos no carrinho' }, { status: 500 });
+  }
+}

--- a/src/app/category/category-client.tsx
+++ b/src/app/category/category-client.tsx
@@ -53,7 +53,7 @@ function groupProductsBySubcategory(
 export function CategoryClient() {
   const searchParams = useSearchParams();
   const { setSelectedCategoryId, filteredCategory, isLoadingCategories, markLocalMutation } = useCategories();
-  const { removeProduct, toggleCart, managerProduct, isProductLoading } = useProducts();
+  const { removeProduct, toggleCart, toggleBatchCart, managerProduct, isProductLoading } = useProducts();
 
   const categoryId = searchParams.get('id');
 
@@ -275,6 +275,18 @@ export function CategoryClient() {
     };
   }, [filteredCategory?.products]);
 
+  const handleToggleAllPending = () => {
+    if (!filteredCategory?._id || productsNotInCart.length === 0) return;
+    const productIds = productsNotInCart.map(p => p._id!).filter(Boolean);
+    void toggleBatchCart(filteredCategory._id, true, productIds);
+  };
+
+  const handleToggleAllInCart = () => {
+    if (!filteredCategory?._id || productsInCart.length === 0) return;
+    const productIds = productsInCart.map(p => p._id!).filter(Boolean);
+    void toggleBatchCart(filteredCategory._id, false, productIds);
+  };
+
   if (isLoadingCategories && !filteredCategory) {
     return <CategoryPageSkeleton />;
   }
@@ -326,6 +338,8 @@ export function CategoryClient() {
               count={productsNotInCart.length}
               isCollapsed={collapsedSections.has('pending')}
               onToggle={() => toggleSection('pending')}
+              onToggleAll={handleToggleAllPending}
+              isAllSelected={false}
             />
             <div className={cn(
               'grid transition-all duration-200',
@@ -392,6 +406,8 @@ export function CategoryClient() {
               count={productsInCart.length}
               isCollapsed={collapsedSections.has('cart')}
               onToggle={() => toggleSection('cart')}
+              onToggleAll={handleToggleAllInCart}
+              isAllSelected={true}
             />
             <div className={cn(
               'grid transition-all duration-200',

--- a/src/components/category-hero-card.tsx
+++ b/src/components/category-hero-card.tsx
@@ -18,7 +18,14 @@ interface CategoryHeroCardProps {
   onRemoveGrouping?: () => Promise<void>;
 }
 
-export function CategoryHeroCard({ isOrganizing, category, products, isRemovingGrouping, onOrganize, onRemoveGrouping }: CategoryHeroCardProps) {
+export function CategoryHeroCard({
+  isOrganizing,
+  category,
+  products,
+  isRemovingGrouping,
+  onOrganize,
+  onRemoveGrouping,
+}: CategoryHeroCardProps) {
   const [isOpen, setIsOpen] = useState(true);
 
   async function handleShare() {

--- a/src/components/section-header.tsx
+++ b/src/components/section-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronDown } from 'lucide-react';
+import { Check, Minus, ChevronDown } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -9,27 +9,72 @@ interface SectionHeaderProps {
   title: string;
   isCollapsed: boolean;
   onToggle: () => void;
+  onToggleAll?: () => void;
+  isAllSelected?: boolean;
+  indeterminate?: boolean;
 }
 
-export function SectionHeader({ count, title, isCollapsed, onToggle }: SectionHeaderProps) {
+export function SectionHeader({
+  count,
+  title,
+  isCollapsed,
+  onToggle,
+  onToggleAll,
+  isAllSelected,
+  indeterminate,
+}: SectionHeaderProps) {
   return (
-    <button
-      onClick={onToggle}
-      className='flex w-full items-center justify-between'
-    >
-      <span className='text-base font-semibold text-[var(--color-ink)]'>{title}</span>
-      <div className='flex items-center gap-2'>
-        <div className='flex h-6 w-7 items-center justify-center rounded-full bg-[var(--color-primary)]'>
-          <span className='text-[12px] font-semibold text-[var(--color-on-primary)]'>{count}</span>
+    <div className="flex w-full items-center justify-between gap-2">
+      <div className="flex items-center gap-2.5 min-w-0">
+        {onToggleAll && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleAll();
+            }}
+            className={cn(
+              'flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+              isAllSelected || indeterminate
+                ? 'bg-[var(--color-primary)] border-[var(--color-primary)]'
+                : 'bg-[var(--color-canvas)] border-[var(--color-hairline)] hover:border-[var(--color-ink)]'
+            )}
+            aria-label={`Selecionar todos em ${title}`}
+            title={`Selecionar todos em ${title}`}
+          >
+            {isAllSelected && (
+              <Check className="h-3.5 w-3.5 text-[var(--color-on-primary)]" />
+            )}
+            {!isAllSelected && indeterminate && (
+              <Minus className="h-3.5 w-3.5 text-[var(--color-on-primary)]" />
+            )}
+          </button>
+        )}
+        <button
+          onClick={onToggle}
+          type="button"
+          className="flex items-center text-left truncate focus:outline-none"
+        >
+          <span className="text-base font-semibold text-[var(--color-ink)] truncate">{title}</span>
+        </button>
+      </div>
+
+      <button
+        onClick={onToggle}
+        type="button"
+        className="flex items-center gap-2 shrink-0 focus:outline-none"
+      >
+        <div className="flex h-6 w-7 items-center justify-center rounded-full bg-[var(--color-primary)]">
+          <span className="text-[12px] font-semibold text-[var(--color-on-primary)]">{count}</span>
         </div>
         <ChevronDown
-          aria-hidden='true'
+          aria-hidden="true"
           className={cn(
             'h-4 w-4 text-[var(--color-muted)] transition-transform duration-200',
             isCollapsed && '-rotate-90'
           )}
         />
-      </div>
-    </button>
+      </button>
+    </div>
   );
 }

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Check } from 'lucide-react';
+import { Check, Minus } from 'lucide-react';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 
 import { cn } from '@/lib/utils';
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground',
       className
     )}
     {...props}
@@ -21,7 +21,11 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn('flex items-center justify-center text-current')}
     >
-      <Check className="h-4 w-4" />
+      {props.checked === 'indeterminate' ? (
+        <Minus className="h-4 w-4" />
+      ) : (
+        <Check className="h-4 w-4" />
+      )}
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -373,8 +373,25 @@ function CategoriesContextProvider({ children }: CategoryProviderProps) {
   };
 
   const fetchCategories = useCallback(async () => {
-    // No-op: initial load is handled by onSnapshot
+    try {
+      setIsLoadingCategories(true);
+      const response = await fetch('/api/categories');
+      if (response.ok) {
+        const data = await response.json();
+        setCategories(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch categories:', err);
+    } finally {
+      setIsLoadingCategories(false);
+    }
   }, []);
+
+  useEffect(() => {
+    if (sessionStatus === AuthStatusEnum.authenticated) {
+      void fetchCategories();
+    }
+  }, [sessionStatus, fetchCategories]);
 
   const filterCategory = useCallback(
     (categoryId: string) => {

--- a/src/context/ProductContext.tsx
+++ b/src/context/ProductContext.tsx
@@ -31,6 +31,7 @@ interface ProductsContextType {
   toggleCart: (id: string) => Promise<void>;
   removeProduct: (id: string) => Promise<void>;
   managerProduct: ({ product }: { product: ProductProps }) => Promise<void>;
+  toggleBatchCart: (categoryId: string, addToCart: boolean, productIds?: string[]) => Promise<void>;
 }
 
 interface ProductsProviderProps {
@@ -280,6 +281,59 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
     }
   };
 
+  const toggleBatchCart = async (
+    categoryId: string,
+    addToCart: boolean,
+    productIds?: string[]
+  ) => {
+    if (!categoryId) return;
+
+    const previousCategories = categories;
+
+    setCategories(prev => prev.map(category => {
+      if (category._id !== categoryId) return category;
+
+      return {
+        ...category,
+        products: category.products?.map(product => {
+          if (!productIds || productIds.includes(product._id!)) {
+            return { ...product, addToCart };
+          }
+          return product;
+        })
+      };
+    }));
+
+    try {
+      const affectedCount = productIds ? productIds.length : (
+        categories.find(c => c._id === categoryId)?.products?.length ?? 1
+      );
+      markLocalMutation(affectedCount);
+
+      const response = await fetch(`/api/categories/${categoryId}/cart`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ addToCart, productIds }),
+      });
+
+      if (!response.ok) {
+        markLocalMutation(-affectedCount);
+        setCategories(previousCategories);
+        toast.error('Erro ao atualizar produtos no carrinho');
+        throw new Error('Failed to update products in cart');
+      }
+
+      if (addToCart) {
+        toast.success('Produtos adicionados ao carrinho');
+      } else {
+        toast.success('Produtos removidos do carrinho');
+      }
+    } catch (err) {
+      setCategories(previousCategories);
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
   useEffect(() => {
     verifyHasAnyProduct();
   }, [allProductsCategory, verifyHasAnyProduct]);
@@ -291,6 +345,7 @@ function ProductsContextProvider({ children }: ProductsProviderProps) {
         filter,
         setFilter,
         toggleCart,
+        toggleBatchCart,
         hasAnyProduct,
         removeProduct,
         managerProduct,

--- a/src/lib/firestore-domain.ts
+++ b/src/lib/firestore-domain.ts
@@ -315,6 +315,45 @@ export async function updateProduct(userId: string, productId: string, product: 
   return productFromDoc(updatedProductDoc, category);
 }
 
+export async function toggleBatchCart(
+  userId: string,
+  categoryId: string,
+  addToCart: boolean,
+  productIds?: string[]
+): Promise<boolean> {
+  const result = await getAccessibleCategory(categoryId, userId);
+
+  if (!result) return false;
+
+  const { ownerUserId } = result;
+
+  const snapshot = await productsCollection
+    .where('userId', '==', ownerUserId)
+    .where('categoryId', '==', categoryId)
+    .get();
+
+  if (snapshot.empty) return true;
+
+  const batch = firestore.batch();
+  let count = 0;
+
+  for (const doc of snapshot.docs) {
+    if (!productIds || productIds.includes(doc.id)) {
+      batch.update(doc.ref, {
+        addToCart,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      count++;
+    }
+  }
+
+  if (count > 0) {
+    await batch.commit();
+  }
+
+  return true;
+}
+
 export async function deleteProduct(userId: string, productId: string) {
   const productDoc = await getAccessibleProductDoc(productId, userId);
 


### PR DESCRIPTION
## Descrição
Implementa a funcionalidade para selecionar e desselecionar todos os itens do carrinho de uma só vez nos cabeçalhos das seções 'Fora do carrinho' e 'Carrinho'.

## Alterações
- Endpoint PATCH /api/categories/[id]/cart e função 	oggleBatchCart no Firestore Domain.
- Atualização em lote no ProductContext com suporte a estado otimista.
- Botão de check em lote nos cabeçalhos das seções (SectionHeader).
- Suporte ao estado indeterminado (Minus icon) no componente Checkbox.